### PR TITLE
added some semantic sugar to yield the frozen time back into the block

### DIFF
--- a/lib/timecop/timecop.rb
+++ b/lib/timecop/timecop.rb
@@ -88,7 +88,7 @@ class Timecop
     
       if block_given?
         begin
-          yield
+          yield stack_item.time
         ensure
           # pull it off the stack...
           @_stack.pop

--- a/test/test_timecop.rb
+++ b/test/test_timecop.rb
@@ -24,6 +24,12 @@ class TestTimecop < Test::Unit::TestCase
     end
     assert_not_equal t, Time.now
   end
+
+  def test_freeze_yields_mocked_time
+    Timecop.freeze(2008, 10, 10, 10, 10, 10) do |frozen_time|
+      assert_equal frozen_time, Time.now
+    end
+  end
   
   def test_freeze_then_return_unsets_mock_time
     Timecop.freeze(1)
@@ -237,6 +243,14 @@ class TestTimecop < Test::Unit::TestCase
       assert_times_effectively_equal(t, Time.now, 2, "Failed to restore previously-traveled time.")
     end
     assert_nil Time.send(:mock_time)
+  end
+
+  def test_recursive_travel_yields_correct_time
+    Timecop.travel(2008, 10, 10, 10, 10, 10) do 
+      Timecop.travel(2008, 9, 9, 9, 9, 9) do |inner_freeze|
+        assert_times_effectively_equal inner_freeze, Time.now, 1, "Failed to yield current time back to block"
+      end
+    end
   end
   
   def test_recursive_travel_then_freeze


### PR DESCRIPTION
Love timecop and use it regularly, but when you use the literal syntax of 

``` ruby
Timecop.freeze(2001, 01, 01) do
  # do things
end
```

you are forced to either a) use Time.now as your expected, or b) extract a variable for that time literal (which you probably want if you use timecop more then once in a test). Neither are particularly bad or onerous things, but I thought it may be nice to be able to say

``` ruby
Timecop.freeze(2001, 01, 01) do |posted_at|
  # do things
end

Timecop.freeze(2000, 01, 01) do |before_posting|
  # do things
end
```

 and have timecop handle the variable declaration for you, instead of 

``` ruby
posted_at = Time.local(2001, 01, 01)
Timecop.freeze(posted_at)
  # do things
end

before_post = Time.local(2000, 01, 01)
Timecop.freeze(before_post)
  # do things
end
```
