### PR TITLE
Timecop.freeze & Timecop.travel without param

### DIFF
--- a/lib/timecop/time_stack_item.rb
+++ b/lib/timecop/time_stack_item.rb
@@ -87,6 +87,8 @@ class Timecop
           Time.local(arg.year, arg.month, arg.day, 0, 0, 0)
         elsif args.empty? && arg.kind_of?(Integer)
           Time.now + arg
+        elsif arg.nil?
+          Time.now
         else # we'll just assume it's a list of y/m/d/h/m/s
           year   = arg        || 0
           month  = args.shift || 1

--- a/test/test_timecop.rb
+++ b/test/test_timecop.rb
@@ -291,4 +291,12 @@ class TestTimecop < Test::Unit::TestCase
     assert times_effectively_equal(t_real, t_return)
   end
 
+  def test_freeze_without_params
+    Timecop.freeze 1 do
+      current_time = Time.now
+      Timecop.freeze do
+        assert_equal Time.now, current_time
+      end
+    end
+  end
 end


### PR DESCRIPTION
default to Time.now when no params instead of '0000-01-01 08:00:00.000000'
