### PR TITLE
Ruby 1.9.2+ fix for Timecop

### DIFF
--- a/lib/timecop/time_stack_item.rb
+++ b/lib/timecop/time_stack_item.rb
@@ -88,7 +88,7 @@ class Timecop
         elsif args.empty? && arg.kind_of?(Integer)
           Time.now + arg
         else # we'll just assume it's a list of y/m/d/h/m/s
-          year   = arg        || 0
+          year   = arg        || 2000
           month  = args.shift || 1
           day    = args.shift || 1
           hour   = args.shift || 0


### PR DESCRIPTION
Hey John,

Between Ruby 1.9.1 and 1.9.2, Date.local changed. In 1.9.1 and earlier, passing a 1 or 2 digit would set the year to that year of the current century. In 1.9.2+, it sets it to 00(0)<your argument>, which causes problems if you're using Timecop.freeze with no arguments in tests dealing with setting default timestamp values.

I've forked Timecop and patched this (have it set to 2000, so that default behavior is maintained) so we can continue using it for our project, and I'm not sure how actively you're maintaining the original gem, but I figured I'd throw this upstream and see if it's something you want to pull in.

Thanks!

--Michael
