### PR TITLE
Timecop .travel, .freeze and .return return nil or block value.

### DIFF
--- a/lib/timecop/timecop.rb
+++ b/lib/timecop/timecop.rb
@@ -47,10 +47,11 @@ class Timecop
     #   which will lead to files being generated with the timestamp set by the Timecop.freeze call
     #   in your dev environment
     #
-    # Returns the frozen time.
+    # Returns the value of the block or nil.
     def freeze(*args, &block)
-      instance().send(:travel, :freeze, *args, &block)
-      Time.now
+      val = instance().send(:travel, :freeze, *args, &block)
+
+      block_given? ? val : nil
     end
 
     # Allows you to run a block of code and "fake" a time throughout the execution of that block.
@@ -59,10 +60,11 @@ class Timecop
     # * Note: Timecop.travel will not freeze time (as opposed to Timecop.freeze).  This is a particularly
     #   good candidate for use in environment files in rails projects.
     #
-    # Returns the 'new' current Time.
+    # Returns the value of the block or nil.
     def travel(*args, &block)
-      instance().send(:travel, :travel, *args, &block)
-      Time.now
+      val = instance().send(:travel, :travel, *args, &block)
+
+      block_given? ? val : nil
     end
 
     def baseline
@@ -74,11 +76,9 @@ class Timecop
     end
 
     # Reverts back to system's Time.now, Date.today and DateTime.now (if it exists).
-    #
-    # Returns Time.now, which is now the real current time.
     def return
       instance().send(:unmock!)
-      Time.now
+      nil
     end
 
     def return_to_baseline

--- a/test/timecop_test.rb
+++ b/test/timecop_test.rb
@@ -321,29 +321,34 @@ class TestTimecop < Test::Unit::TestCase
     assert_nil Time.send(:mock_time)
   end
 
-  def test_return_values_are_Time_instances
-    assert Timecop.freeze.is_a?(Time)
-    assert Timecop.travel.is_a?(Time)
-    assert Timecop.return.is_a?(Time)
-  end
-
-  def test_travel_time_returns_passed_value
+  def test_travel_time_returns_nil
     t_future = Time.local(2030, 10, 10, 10, 10, 10)
-    t_travel = Timecop.travel t_future
-    assert times_effectively_equal(t_future, t_travel)
+    assert_nil Timecop.travel(t_future)
   end
 
-  def test_freeze_time_returns_passed_value
+  def test_travel_time_with_block_returns_the_value_of_the_block
     t_future = Time.local(2030, 10, 10, 10, 10, 10)
-    t_frozen = Timecop.freeze t_future
-    assert times_effectively_equal(t_future, t_frozen)
+    expected = :foo
+    actual = Timecop.travel(t_future) { expected }
+
+    assert_equal expected, actual
   end
 
-  def test_return_time_returns_actual_time
-    t_real = Time.now
-    Timecop.freeze Time.local(2030, 10, 10, 10, 10, 10)
-    t_return = Timecop.return
-    assert times_effectively_equal(t_real, t_return)
+  def test_freeze_time_returns_nil
+    t_future = Time.local(2030, 10, 10, 10, 10, 10)
+    assert_nil Timecop.freeze(t_future)
+  end
+
+  def test_freeze_time_with_block_returns_the_value_of_the_block
+    t_future = Time.local(2030, 10, 10, 10, 10, 10)
+    expected = :foo
+    actual = Timecop.freeze(t_future) { expected }
+
+    assert_equal expected, actual
+  end
+
+  def test_return_returns_nil
+    assert_nil Timecop.return
   end
 
   def test_freeze_without_params


### PR DESCRIPTION
As @travisjeffery and I [discussed on twitter today](https://twitter.com/travisjeffery/status/235127882006016000), I was surprised that the return value of Timecop.travel was not the value of the block passed in. I think it would be handy to be able to write code like this in tests:

```
old_user = Timecop.travel(Time.at(0)) { User.create }
```

I've gone ahead and implemented code that does this for `.travel`, `.freeze` and `.return` (the last one for consistency). `.return_to_baseline` still returns Time.now because the docs don't mention what it does and I wasn't sure what do there. I also wasn't sure what do in the case where a block is not passed in, so I made those cases return an explicit nil to prevent reliance on an implementation detail.
