### PR TITLE
Use Travis CI service

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: ruby
+rvm:
+  - 1.9.3
+  - 1.9.2
+  - jruby-18mode
+  - jruby-19mode
+  - rbx-18mode
+  - rbx-19mode
+  - ruby-head
+  - 1.8.7
+  - ree


### PR DESCRIPTION
This commit adds a Travis CI configuration file which will run all the tests for the project against 1.8.7, 1.9.2, 1.9.3, Jruby, Rubinius and REE each time commits are pushed to the project.

The service hook for Travis CI will need to be set up for the project once this pull request is merged, see [Travis CI - Getting started](http://about.travis-ci.org/docs/user/getting-started/) for details.
