### PR TITLE
Update README.markdown

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -1,6 +1,6 @@
 # timecop
 
-- Source[http://github.com/jtrupiano/timecop]
+- Source[http://github.com/travisjeffery/timecop]
 - Documentation[http://johntrupiano.rubyforge.org/timecop]
 
 ## DESCRIPTION


### PR DESCRIPTION
Update link to official repository

Would it be possible to update the links on the rubygems page?
http://rubygems.org/gems/timecop

Thanks for all your hard work!

Gregory
