### PR TITLE
Add in_realtime method

### DIFF
--- a/lib/timecop/timecop.rb
+++ b/lib/timecop/timecop.rb
@@ -141,6 +141,7 @@ class Timecop
     current_baseline = @baseline
     unmock!
     yield
+  ensure
     @_stack = current_stack
     @baseline = current_baseline
   end

--- a/test/timecop_test.rb
+++ b/test/timecop_test.rb
@@ -362,6 +362,38 @@ class TestTimecop < Test::Unit::TestCase
 
   end
 
+  class TestError < RuntimeError; end;
+
+  def test_return_resets_to_current_time_when_exceptio_occurrs
+    t_future = Time.local(2030, 10, 10, 10, 10, 10)
+    t_past = Time.local(2010, 10, 10, 10, 10, 10)
+    
+    Timecop.return
+    now = Time.now
+
+    Timecop.travel t_future
+    assert (Time.now - 30) > now
+    assert_raises TestError do
+      Timecop.in_realtime do
+        assert (Time.now - 30) < now
+        assert Time.now >= now
+        raise TestError
+      end
+    end
+
+    Timecop.travel t_past
+    assert (Time.now + 30) < now
+    assert_raises TestError do
+      Timecop.in_realtime do
+        assert (Time.now - 30) < now
+        assert Time.now >= now
+        raise TestError
+      end
+    end
+
+    assert (Time.now + 30) < now
+  end
+
   def test_travel_time_with_block_returns_the_value_of_the_block
     t_future = Time.local(2030, 10, 10, 10, 10, 10)
     expected = :foo


### PR DESCRIPTION
Easy way to execute some code in the real time without having to call Timecop.reset and then re-freezing / traveling when you're done. My particular use case was testing posting to S3, which will verify the timestamp that's part of the signature it's too far off from realtime.
