### PR TITLE
Fixed issues #49, failing with Ruby1.8

### DIFF
--- a/lib/timecop/time_extensions.rb
+++ b/lib/timecop/time_extensions.rb
@@ -67,4 +67,15 @@ if Object.const_defined?(:DateTime) && DateTime.respond_to?(:now)
       alias_method :now, :now_with_mock_time
     end
   end
+
+  # for ruby1.8
+  unless Time::public_instance_methods.include? :to_datetime
+    class DateTime
+      class << self
+        def now_without_mock_time
+          Time.now_without_mock_time.send(:to_datetime)
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
If Ruby1.8, override the "DateTime # now_without_mock_time" method.

For the issues https://github.com/travisjeffery/timecop/issues/49
