### PR TITLE
add license information to the gemspec

### DIFF
--- a/timecop.gemspec
+++ b/timecop.gemspec
@@ -40,6 +40,7 @@ Gem::Specification.new do |s|
   s.rubyforge_project = %q{timecop}
   s.rubygems_version = %q{1.3.7}
   s.summary = %q{A gem providing "time travel" and "time freezing" capabilities, making it dead simple to test time-dependent code.  It provides a unified method to mock Time.now, Date.today, and DateTime.now in a single call.}
+  s.license = "MIT"
   s.test_files = [
     "test/test_helper.rb",
      "test/time_stack_item_test.rb",


### PR DESCRIPTION
this way it can be used with rubygems.org API
