### PR TITLE
Nanosecond fix

### DIFF
--- a/lib/timecop/time_stack_item.rb
+++ b/lib/timecop/time_stack_item.rb
@@ -104,11 +104,7 @@ class Timecop
         time_klass = Time.respond_to?(:zone) && Time.zone ? Time.zone : Time
         arg = args.shift
         if arg.is_a?(Time)
-          if Timecop.active_support != false && arg.respond_to?(:in_time_zone)
-            arg.in_time_zone
-          else
-            arg.getlocal
-          end
+          arg
         elsif Object.const_defined?(:DateTime) && arg.is_a?(DateTime)
           expected_time = time_klass.local(arg.year, arg.month, arg.day, arg.hour, arg.min, arg.sec)
           expected_time += expected_time.utc_offset - rational_to_utc_offset(arg.offset)


### PR DESCRIPTION
The main goal here was to keep nanoseconds when using ActiveSupport. Turns out there was an issue with ActiveSupport (https://github.com/rails/rails/pull/9403) that is the real cause. I've ported that workaround into Timecop for now.

Also added some tests and did a little refactor on TimeStackItem#parse_time. I'm not sure that the Timecop.active_support config variable is necessary now at all, but I didn't want to totally pull it out since I wasn't sure about the use case.

If you'd like to only take part of these changes, or want the commits squashed, let me know and I'll tweak it.
