### PR TITLE
[Bug fix] Timezones travel/freeze losing zone awareness on to_date or Date.today

### DIFF
--- a/lib/timecop/time_stack_item.rb
+++ b/lib/timecop/time_stack_item.rb
@@ -50,21 +50,21 @@ class Timecop
         @scaling_factor
       end
 
-      def time(time_klass = Time) #:nodoc:
+      def time(klass = time_klass) #:nodoc:
         begin
-          actual_time = time_klass.at(@time)
-          calculated_time = time_klass.at(@time.to_f)
+          actual_time = klass.at(@time)
+          calculated_time = klass.at(@time.to_f)
           time = times_are_equal_within_epsilon(actual_time, calculated_time, 1) ? actual_time : calculated_time
         rescue
-          time = time_klass.at(@time.to_f)
+          time = klass.at(@time.to_f)
         end
 
         if travel_offset.nil?
           time
         elsif scaling_factor.nil?
-          time_klass.at(Time.now_without_mock_time + travel_offset)
+          klass.at(Time.now_without_mock_time + travel_offset)
         else
-          time_klass.at(scaled_time)
+          klass.at(scaled_time)
         end
       end
 
@@ -103,7 +103,6 @@ class Timecop
       end
 
       def parse_time(*args)
-        time_klass = Time.respond_to?(:zone) && Time.zone ? Time.zone : Time
         arg = args.shift
         if arg.is_a?(Time)
           if Timecop.active_support != false && arg.respond_to?(:in_time_zone)
@@ -150,6 +149,10 @@ class Timecop
 
       def times_are_equal_within_epsilon t1, t2, epsilon_in_seconds
         (t1 - t2).abs < epsilon_in_seconds
+      end
+
+      def time_klass
+        Time.respond_to?(:zone) ? Time.zone : Time
       end
     end
   end

--- a/lib/timecop/timecop.rb
+++ b/lib/timecop/timecop.rb
@@ -107,7 +107,7 @@ class Timecop
     private
     def send_travel(mock_type, *args, &block)
       val = instance.send(:travel, mock_type, *args, &block)
-      block_given? ? val : Time.now  
+      block_given? ? val : Time.now
     end
   end
 

--- a/test/time_stack_item_test.rb
+++ b/test/time_stack_item_test.rb
@@ -192,6 +192,16 @@ class TestTimeStackItem < Test::Unit::TestCase
     end
   end
 
+  def test_timezones_apply_dates
+    require 'active_support/all'
+    Time.zone = "Marshall Is."
+    time = Time.zone.local(2013,1,3)
+
+    Timecop.freeze(time) do
+      assert_equal time.to_date, Date.today
+    end
+  end
+
   def test_set_scaling_factor_for_scale
     t_now = Time.now
     t = Time.local(2009, 10, 1, 0, 0, 30)
@@ -247,7 +257,7 @@ class TestTimeStackItem < Test::Unit::TestCase
 
   def test_time_with_different_timezone
     require 'active_support/all'
-    
+
     Time.zone = "Tokyo"
     t = Time.now
     Timecop.freeze(t) do


### PR DESCRIPTION
Hi,

For edge cases with odd timezones, I noticed a bug where certain (+12hr) zones would create an incorrect `to_date` or `Date.today`.

I've used `Marshall Is.` as an example as they are +12 and generally made my tests fail.

The bug was caused by TimeStackItem on call of `def date` would not pass the current Time object, which may be Time.zone applicable. Thus on `to_date` the tz applicable values are stripped, rather than converted.

Best regards,

Tom
