### PR TITLE
Make TimeCop work with Date/DateTime even if Timecop was loaded first

### DIFF
--- a/lib/timecop/time_extensions.rb
+++ b/lib/timecop/time_extensions.rb
@@ -1,3 +1,4 @@
+require 'date'
 
 class Time #:nodoc:
   class << self
@@ -24,52 +25,48 @@ class Time #:nodoc:
   end
 end 
 
-if Object.const_defined?(:Date) && Date.respond_to?(:today)
-  class Date #:nodoc:
-    class << self
-      def mock_date
-        mocked_time_stack_item = Timecop.top_stack_item
-        mocked_time_stack_item.nil? ? nil : mocked_time_stack_item.date(self)
-      end
-      
-      alias_method :today_without_mock_date, :today
-    
-      def today_with_mock_date
-        mock_date || today_without_mock_date
-      end
-    
-      alias_method :today, :today_with_mock_date
+class Date #:nodoc:
+  class << self
+    def mock_date
+      mocked_time_stack_item = Timecop.top_stack_item
+      mocked_time_stack_item.nil? ? nil : mocked_time_stack_item.date(self)
     end
+    
+    alias_method :today_without_mock_date, :today
+    
+    def today_with_mock_date
+      mock_date || today_without_mock_date
+    end
+    
+    alias_method :today, :today_with_mock_date
   end
 end
 
-if Object.const_defined?(:DateTime) && DateTime.respond_to?(:now)
-  class DateTime #:nodoc:
-    class << self
-      def mock_time
-        mocked_time_stack_item = Timecop.top_stack_item
-        mocked_time_stack_item.nil? ? nil : mocked_time_stack_item.datetime(self)
-      end
-      
-      def now_without_mock_time
-        Time.now_without_mock_time.to_datetime
-      end
-      
-      def now_with_mock_time
-        mock_time || now_without_mock_time
-      end
-
-      alias_method :now, :now_with_mock_time
+class DateTime #:nodoc:
+  class << self
+    def mock_time
+      mocked_time_stack_item = Timecop.top_stack_item
+      mocked_time_stack_item.nil? ? nil : mocked_time_stack_item.datetime(self)
     end
-  end
+    
+    def now_without_mock_time
+      Time.now_without_mock_time.to_datetime
+    end
+    
+    def now_with_mock_time
+      mock_time || now_without_mock_time
+    end
 
-  # for ruby1.8
-  unless Time::public_instance_methods.include? :to_datetime
-    class DateTime
-      class << self
-        def now_without_mock_time
-          Time.now_without_mock_time.send(:to_datetime)
-        end
+    alias_method :now, :now_with_mock_time
+  end
+end
+
+# for ruby1.8
+unless Time::public_instance_methods.include? :to_datetime
+  class DateTime
+    class << self
+      def now_without_mock_time
+        Time.now_without_mock_time.send(:to_datetime)
       end
     end
   end

--- a/test/timecop_loaded_before_date_test.rb
+++ b/test/timecop_loaded_before_date_test.rb
@@ -1,0 +1,40 @@
+# When this test is running under 'bundle exec', it "helpfully" adds
+# '-rbundler/setup' to RUBYOPT, which in turn loads the Date/DateTime classes
+# (in some versions of Bundler.)  But the bug we're trying to test for here only
+# occurs if timecop was loaded before Date/DateTime.  So we have to detect if
+# 'date' was already loaded here and rip it out before running the test.
+if Object.const_defined?(:Date) && Date.respond_to?(:today)
+  Object.send(:remove_const, :Date)
+  Object.send(:remove_const, :DateTime)
+  $LOADED_FEATURES.delete('date')
+end
+
+# Require timecop first, before anything else that would load 'date'
+require File.join(File.dirname(__FILE__), '..', 'lib', 'timecop')
+require File.join(File.dirname(__FILE__), "test_helper")
+require 'date'
+
+class TestTimecopWithoutDate < Test::Unit::TestCase
+  # just in case...let's really make sure that Timecop is disabled between tests...
+  def teardown
+    Timecop.return
+  end
+
+  def test_freeze_changes_and_resets_date
+    t = Date.new(2008, 10, 10)
+    assert_not_equal t, Date.today
+    Timecop.freeze(2008, 10, 10) do
+      assert_equal t, Date.today
+    end
+    assert_not_equal t, Date.today
+  end
+
+  def test_freeze_changes_and_resets_datetime
+    t = DateTime.new(2008, 10, 10, 0, 0, 0, 0)
+    assert_not_equal t, DateTime.now
+    Timecop.freeze(t) do
+      assert_date_times_equal t, DateTime.now
+    end
+    assert_not_equal t, DateTime.now
+  end
+end


### PR DESCRIPTION
This makes TimeCop load 'date' instead when it loads, so that it can patch Date and DateTime as expected.  Without this patch, you can get unexpected behavior in cases where Date or DateTime is used, but TimeCop was loaded before 'date'.  See my longwinded comment in #83.
