### PR TITLE
Fix Active Support dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ end
 group :development, :test do
   gem 'pry'
   gem 'mocha', :require => false
-  gem 'active_support', :require => "active_support/all"
+  gem 'activesupport', :require => "active_support/all"
   gem 'tzinfo'
   gem 'i18n'
   gem 'minitest-reporters'


### PR DESCRIPTION
The correct name of the gem is [activesupport](https://rubygems.org/gems/activesupport), the other name [was created by someone else](https://rubygems.org/gems/active_support).

---

I am having a problem with testing this gem and Rails 4.0.0.rc2 (that's how I noticed this issue). The following test case can showcase the problem:

``` ruby
  def test_activesupport
    require 'active_support/all'
    puts "AS #{ActiveSupport::VERSION::STRING}"

    Timecop.travel Time.utc(2014, 6, 12, 17) do
      puts Time.now.strftime('%Y-%m-%d %H:%M:%S + %L')
      sleep 0.05
      puts Time.now.strftime('%Y-%m-%d %H:%M:%S + %L')
      sleep 0.05
      puts Time.now.strftime('%Y-%m-%d %H:%M:%S + %L')
      sleep 0.05
      puts Time.now.strftime('%Y-%m-%d %H:%M:%S + %L')
      sleep 0.05
      puts Time.now.strftime('%Y-%m-%d %H:%M:%S + %L')
      sleep 0.5
      puts Time.now.strftime('%Y-%m-%d %H:%M:%S + %L')
    end
  end
```

Under Rails 3.2.x, it results in something like:

```
[ 1/45] TestTimecop#test_activesupportAS 3.2.12
2014-06-12 14:00:00 + 000
2014-06-12 14:00:00 + 051
2014-06-12 14:00:00 + 102
2014-06-12 14:00:00 + 153
2014-06-12 14:00:00 + 204
2014-06-12 14:00:00 + 705
```

But under 4.0.0.rc2, it's this:

```
[ 1/45] TestTimecop#test_activesupportAS 4.0.0.rc2
2014-06-12 14:00:00 + 000
2014-06-12 14:00:00 + 000
2014-06-12 14:00:00 + 000
2014-06-12 14:00:00 + 000
2014-06-12 14:00:00 + 000
2014-06-12 14:00:00 + 000
```

As you can see, apparently milliseconds are not being updated as expected. This is resulting in Capybara throwing `FrozenInTime` errors when using the javascript driver and Timecop's time travel feature. I didn't have time to look further on a solution yet, just wanted to post here so that maybe someone else might have a hunch about the fix or if I'm doing something very wrong :).

Thanks!
