### PR TITLE
fix timecop_loaded_before_date_test.rb on ruby 1.9.3

### DIFF
--- a/test/timecop_loaded_before_date_test.rb
+++ b/test/timecop_loaded_before_date_test.rb
@@ -6,7 +6,7 @@
 if Object.const_defined?(:Date) && Date.respond_to?(:today)
   Object.send(:remove_const, :Date)
   Object.send(:remove_const, :DateTime)
-  $LOADED_FEATURES.delete('date')
+  $LOADED_FEATURES.select {|f| f =~ /date/ }.each {|f| $LOADED_FEATURES.delete(f) }
 end
 
 # Require timecop first, before anything else that would load 'date'


### PR DESCRIPTION
```
$ rake
Run options:

# Running tests:

.........................

Finished tests in 0.029415s, 849.9065 tests/s, 2345.7420 assertions/s.

25 tests, 69 assertions, 0 failures, 0 errors, 0 skips
/Users/neer/src/neerfri/timecop/lib/timecop/time_extensions.rb:35:in `alias_method': undefined method `today' for class `Class' (NameError)
    from /Users/neer/src/neerfri/timecop/lib/timecop/time_extensions.rb:35:in `singletonclass'
    from /Users/neer/src/neerfri/timecop/lib/timecop/time_extensions.rb:29:in `<class:Date>'
    from /Users/neer/src/neerfri/timecop/lib/timecop/time_extensions.rb:28:in `<top (required)>'
    from /Users/neer/src/neerfri/timecop/lib/timecop/timecop.rb:2:in `require'
    from /Users/neer/src/neerfri/timecop/lib/timecop/timecop.rb:2:in `<top (required)>'
    from /Users/neer/src/neerfri/timecop/lib/timecop.rb:1:in `require'
    from /Users/neer/src/neerfri/timecop/lib/timecop.rb:1:in `<top (required)>'
    from timecop_loaded_before_date_test.rb:14:in `require'
    from timecop_loaded_before_date_test.rb:14:in `<main>'
Run options:

# Running tests:

............................................

Finished tests in 0.517172s, 85.0781 tests/s, 216.5624 assertions/s.

44 tests, 112 assertions, 0 failures, 0 errors, 0 skips
Run options:

# Running tests:

.

Finished tests in 0.008462s, 118.1754 tests/s, 118.1754 assertions/s.

1 tests, 1 assertions, 0 failures, 0 errors, 0 skips
Run options:

# Running tests:

........

Finished tests in 0.504621s, 15.8535 tests/s, 59.4506 assertions/s.

8 tests, 30 assertions, 0 failures, 0 errors, 0 skips
1 test cases had failures
rake aborted!

/Users/neer/src/neerfri/timecop/Rakefile:24:in `block in <top (required)>'
./.bundle/binstubs/rake:16:in `load'
./.bundle/binstubs/rake:16:in `<main>'
Tasks: TOP => default => test
(See full trace by running task with --trace)
```
