### PR TITLE
Fix Time.now precision with ActiveSupport 4

### DIFF
--- a/lib/timecop/time_stack_item.rb
+++ b/lib/timecop/time_stack_item.rb
@@ -59,7 +59,7 @@ class Timecop
         if travel_offset.nil?
           time
         elsif scaling_factor.nil?
-          time_klass.at(Time.now_without_mock_time + travel_offset)
+          time_klass.at((Time.now_without_mock_time + travel_offset).to_f)
         else
           time_klass.at(scaled_time)
         end

--- a/test/timecop_with_active_support_test.rb
+++ b/test/timecop_with_active_support_test.rb
@@ -1,0 +1,20 @@
+require 'date'
+require 'active_support/all'
+
+require File.join(File.dirname(__FILE__), "test_helper")
+require File.join(File.dirname(__FILE__), '..', 'lib', 'timecop')
+
+
+class TestTimecopWithActiveSupport < Test::Unit::TestCase
+  def teardown
+    Timecop.return
+  end
+
+  def test_travel_does_not_reduce_precision_of_time
+    Timecop.travel(1)
+    long_ago = Time.now
+    sleep(0.000001)
+    assert_not_equal long_ago.to_f, Time.now.to_f
+  end
+
+end


### PR DESCRIPTION
ActiveSupport 4 adds the following code to `Time` class:

```
    # Layers additional behavior on Time.at so that ActiveSupport::TimeWithZone and DateTime
    # instances can be used when called with a single argument
    def at_with_coercion(*args)
      if args.size == 1 && args.first.acts_like?(:time)
        at_without_coercion(args.first.to_i)
      else
        at_without_coercion(*args)
      end
    end
    alias_method :at_without_coercion, :at
    alias_method :at, :at_with_coercion
```

This makes `Time.now` lose millisecond percision (notice the call to `#to_i`).
With this issue it's problematic to use Timecop with Capybara since it is checking to detect time freezing using a small sleep. this makes the small sleep (while in travel) look like a time freeze.

Should probably also be fixed in ActiveSupport. I'm working on a pull request for that as well. but figured you might want to pull this in in order to make Timecop work now with Rails 4 + Capybara
