### PR TITLE
adding test for issue 72

### DIFF
--- a/test/timecop_test.rb
+++ b/test/timecop_test.rb
@@ -458,5 +458,12 @@ class TestTimecop < Test::Unit::TestCase
       end
     end
   end
-
+ 
+  def test_datetime_nanoseconds_are_preserved
+    # aka issue 72.  NB: this test will randomly pass one in 1000 times.
+    t = DateTime.now
+    Timecop.freeze(t)
+    assert_equal t, DateTime.now
+  end
+ 
 end


### PR DESCRIPTION
Added a short test for issue 72.  It is generating errors of the form:

```
  1) Failure:
TestTimecop#test_datetime_nanoseconds_are_preserved [timecop_test.rb:466]:
<#<DateTime: 2013-07-15T17:33:49-07:00 ((2456490j,2029s,528206000n),-25200s,2299161j)>> expected but was
<#<DateTime: 2013-07-15T17:33:49-07:00 ((2456490j,2029s,528206110n),-25200s,2299161j)>>.
```

Notice that the nanoseconds are getting truncated (528206000n vs 528206110n).

P.S.: Yep, this is my first pull request.  Hope I got it right.
