### PR TITLE
Fix bug when Timecop modifies a timezone of passed object

### DIFF
--- a/lib/timecop/time_stack_item.rb
+++ b/lib/timecop/time_stack_item.rb
@@ -51,7 +51,7 @@ class Timecop
 
       def time(time_klass = Time) #:nodoc:
         if @time.respond_to?(:in_time_zone)
-          time = time_klass.at(@time.utc.to_r)
+          time = time_klass.at(@time.dup.utc.to_r)
         else
           time = time_klass.at(@time)
         end

--- a/test/time_stack_item_test.rb
+++ b/test/time_stack_item_test.rb
@@ -249,6 +249,14 @@ class TestTimeStackItem < Test::Unit::TestCase
     end
   end
 
+  def test_freezing_a_time_leaves_timezone_intact
+    Time.zone = "Tokyo"
+    t = Time.now
+    t_dup = t.dup
+    Timecop.freeze(t) {}
+    assert_equal t_dup.zone, t.zone
+  end
+
   def test_freezing_a_time_with_zone_returns_proper_zones
     Time.zone = "Hawaii"
     t = ActiveSupport::TimeWithZone.new(Time.utc(2000, 1, 1), ActiveSupport::TimeZone['Tokyo'])


### PR DESCRIPTION
In case when <code>ActiveSupport</code> is present <code>Timecop</code> uses destructive <code>utc</code> method on a time object that was passed to it.
