### PR TITLE
Provide correct defaults for Date::strptime

### DIFF
--- a/lib/timecop/time_extensions.rb
+++ b/lib/timecop/time_extensions.rb
@@ -43,7 +43,12 @@ class Date #:nodoc:
 
     alias_method :strptime_without_mock_date, :strptime
 
-    def strptime_with_mock_date(str, fmt)
+    def strptime_with_mock_date(str = '-4712-01-01', fmt = '%F', start = Date::ITALY)
+      unless start == Date::ITALY
+        raise ArgumentError, "Timecop's #{self}::#{__method__} only " +
+                             "supports Date::ITALY for the start argument."
+      end
+
       Time.strptime(str, fmt).to_date
     end
 

--- a/test/timecop_test.rb
+++ b/test/timecop_test.rb
@@ -489,6 +489,12 @@ class TestTimecop < Test::Unit::TestCase
     end
   end
 
+  def test_date_strptime_without_specifying_format
+    Timecop.freeze(Time.new(1984,2,28)) do
+      assert_equal Date.strptime('1999-04-14'), Date.new(1999, 4, 14)
+    end
+  end
+
   private
 
   def with_safe_mode(enabled=true)


### PR DESCRIPTION
Addresses concerns [raised](https://github.com/travisjeffery/timecop/pull/109#issuecomment-29726237) by @dmarkow in #109
