### PR TITLE
Fix failing tests caused by Daylight Savings assumptions

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -24,11 +24,13 @@ class Test::Unit::TestCase
       assert !times_effectively_equal(time1, time2, seconds_interval), "#{msg}: time1 = #{time1.to_s}, time2 = #{time2.to_s}"
     end
     
-    def local_offset
-      DateTime.now_without_mock_time.offset
+    # Gets the local offset (supplied by ENV['TZ'] or your computer's clock)
+    # At the given timestamp, or Time.now if not time is given.
+    def local_offset(time = Time.now)
+      Time.at(time.to_i).to_datetime.offset
     end
   
-    TIMEZONES = ["Europe/Paris", "UTC", "EDT"]
+    TIMEZONES = ["Europe/Paris", "UTC", "America/Chicago"]
   
     def each_timezone
       old_tz = ENV["TZ"]

--- a/test/timecop_test.rb
+++ b/test/timecop_test.rb
@@ -249,6 +249,11 @@ class TestTimecop < Test::Unit::TestCase
     each_timezone do
       t = DateTime.parse("2009-10-11 00:38:00 +0200")
       Timecop.freeze(t) do
+        if ENV['TZ'] == 'UTC'
+          assert_equal(local_offset, 0, "Local offset not be zero for #{ENV['TZ']}")
+        else
+          assert_not_equal(local_offset, 0, "Local offset should not be zero for #{ENV['TZ']}")
+        end
         assert_equal local_offset, DateTime.now.offset, "Failed for timezone: #{ENV['TZ']}"
       end
     end


### PR DESCRIPTION
1. EDT doesn't resolve to a timezone unless the tzinfo-data gem is loaded;
   use 'America/Chicago' instead, since the failure to resolve is transparent
   and results in the local clock's offset being used.
2. The test helper for local_offset needs to know about _when_ we need an
   offset for, since they aren't consistent within named timezones over the
   course of the year.
3. Adds a verification to make sure offsets are being applied at all in the
   mocked time.
