### PR TITLE
Lock minitest-reporters dependency to fix the build

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,5 +15,5 @@ group :development, :test do
   gem 'activesupport', :require => "active_support/all"
   gem 'tzinfo'
   gem 'i18n'
-  gem 'minitest-reporters'
+  gem 'minitest-reporters', '~> 0.14.20'
 end


### PR DESCRIPTION
On 2013-11-23, minitest-reporters released v1.0.0, which instead of
relying on minitest <= 5.0, requires minitest >= 5.0. This change breaks
the travis build since we rely on some deprecated APIs.

This change locks us to the 0.14 series of minitest-reporters.
