### PR TITLE
Add support for DateTime.strptime

### DIFF
--- a/lib/timecop/time_extensions.rb
+++ b/lib/timecop/time_extensions.rb
@@ -72,5 +72,18 @@ class DateTime #:nodoc:
     end
 
     alias_method :now, :now_with_mock_time
+
+    alias_method :strptime_without_mock_date, :strptime
+
+    def strptime_with_mock_date(str = '-4712-01-01T00:00:00+00:00', fmt = '%FT%T%z', start = Date::ITALY)
+      unless start == Date::ITALY
+        raise ArgumentError, "Timecop's #{self}::#{__method__} only " +
+                             "supports Date::ITALY for the start argument."
+      end
+
+      Time.strptime(str, fmt).to_datetime
+    end
+
+    alias_method :strptime, :strptime_with_mock_date
   end
 end

--- a/test/timecop_test.rb
+++ b/test/timecop_test.rb
@@ -491,6 +491,7 @@ class TestTimecop < Test::Unit::TestCase
   def test_date_strptime_without_year
     Timecop.freeze(Time.new(1984,2,28)) do
       assert_equal Date.strptime('04-14', '%m-%d'), Date.new(1984, 4, 14)
+      assert_equal DateTime.strptime('04-14', '%m-%d'), DateTime.new(1984, 4, 14)
     end
   end
 


### PR DESCRIPTION
Full disclosure: basically, when it comes to `Time`/`Date`/`DateTime`, I don't really know what I'm doing.

For the implementation I copied `Date`'s `strptime` code.
