### PR TITLE
Added opt-in feature to scale sleep operations.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -110,6 +110,27 @@ Time.now
 
 See [#42](https://github.com/travisjeffery/timecop/pull/42) for more information, thanks to Ken Mayer, David Holcomb, and Pivotal Labs.
 
+### Timecop.scale_sleep
+
+By default, Timecop won't scale time for sleep operations.  Each call to sleep
+in your code with a duration will reflect "real-world" time rather than
+respecting the scaling factor set by Timecop.scale.  For most uses of
+Timecop.scale, this is the desired behavior.  But if your time-dependent
+application testing requires support for mocking of `Kernel#sleep`
+(and/or `ConditionVariable#wait`), this can be explicitly enabled.
+
+```ruby
+# turn on mocking of sleep operations
+Timecop.scale_sleep = true
+
+# check if mocking of sleep operations is enabled
+Timecop.scale_sleep?
+# => true
+
+Timecop.scale(3600)
+sleep 3600 # This sleep will last only one second in "real-world" time
+```
+
 ### Timecop.safe_mode
 
 Safe mode forces you to use Timecop with the block syntax since it always puts time back the way it was. If you are running in safe mode and use Timecop without the block syntax `Timecop::SafeModeException` will be raised to tell the user they are not being safe.

--- a/lib/timecop/time_extensions.rb
+++ b/lib/timecop/time_extensions.rb
@@ -74,3 +74,33 @@ class DateTime #:nodoc:
     alias_method :now, :now_with_mock_time
   end
 end
+
+module Kernel #:nodoc:
+  alias_method :sleep_without_mock_time_scale, :sleep
+
+  def sleep_with_mock_time_scale duration=nil
+    mocked_time_stack_item = Timecop.scale_sleep? && Timecop.top_stack_item
+    scaling_factor = 1.0
+    scaling_factor *= mocked_time_stack_item.scaling_factor \
+      if mocked_time_stack_item and mocked_time_stack_item.scaling_factor
+    duration = duration / scaling_factor if duration
+    sleep_without_mock_time_scale duration
+  end
+
+  alias_method :sleep, :sleep_with_mock_time_scale
+end
+
+class ConditionVariable #:nodoc:
+  alias_method :wait_without_mock_time_scale, :wait
+
+  def wait_with_mock_time_scale mutex, timeout=nil
+    mocked_time_stack_item = Timecop.scale_sleep? && Timecop.top_stack_item
+    scaling_factor = 1.0
+    scaling_factor *= mocked_time_stack_item.scaling_factor \
+      if mocked_time_stack_item and mocked_time_stack_item.scaling_factor
+    timeout = timeout / scaling_factor if timeout
+    wait_without_mock_time_scale mutex, timeout
+  end
+
+  alias_method :wait, :wait_with_mock_time_scale
+end

--- a/lib/timecop/timecop.rb
+++ b/lib/timecop/timecop.rb
@@ -110,6 +110,14 @@ class Timecop
       false || @safe_mode
     end
 
+    def scale_sleep=(scale_sleep)
+      @scale_sleep = scale_sleep
+    end
+
+    def scale_sleep?
+      !!@scale_sleep
+    end
+
     private
     def send_travel(mock_type, *args, &block)
       val = instance.send(:travel, mock_type, *args, &block)


### PR DESCRIPTION
A lot of my time-dependent code I work with uses sleep operations with specific timings for scheduling events.  These time-dependent snippets are also coupled with the Time-related operations that Timecop already stubs, so the two types of operations always need to be stubbed together for me.  I'm currently using some localized stubbing but I'm now finding it necessary to duplicate this code in several test, so I thought I'd submit a pull request to stub sleep when scale is called.

To be specific, it's usually `ConditionVariable#wait` and not `Kernel#sleep` that I use, but this pull request mocks both, because it is nearly the same operation.

This is a purely opt-in feature and shouldn't change the way `Timecop.scale` works for people already using Timecop in the workflows.  You can opt-in to this expanded stubbing with `Timecop.scale_sleep = true`.

I've tried to match the existing style as much as possible in the implementation, the tests, and the explanation I added to the README (which is in a separate commit, so you can decide if you want it or not).

Let me know if you'd prefer some other way of enabling the feature instead of `Timecop.scale_sleep = true`, and I'd bet we can make it happen.

Thanks for your consideration, and great work so far with Timecop!
