### PR TITLE
Issue when an error is raised in a Timecop.return block

### DIFF
--- a/lib/timecop/timecop.rb
+++ b/lib/timecop/timecop.rb
@@ -150,6 +150,7 @@ class Timecop
     current_baseline = @baseline
     unmock!
     yield
+  ensure
     @_stack = current_stack
     @baseline = current_baseline
   end

--- a/test/timecop_test.rb
+++ b/test/timecop_test.rb
@@ -219,6 +219,14 @@ class TestTimecop < Minitest::Unit::TestCase
     end
   end
 
+  def test_exception_thrown_in_return_block_restores_previous_time
+    t = Time.local(2008, 10, 10, 10, 10, 10)
+    Timecop.freeze(t) do
+      Timecop.return { raise 'foobar' } rescue nil
+      assert_equal t, Time.now
+    end
+  end
+
   def test_freeze_freezes_time
     t = Time.local(2008, 10, 10, 10, 10, 10)
     now = Time.now


### PR DESCRIPTION
Consider this example:

```ruby
Timecop.travel(Time.now - (1 * 24 * 60 * 60)) do
  puts Time.now.to_s
  Timecop.return { puts Time.now.to_s; raise 'foo!' } rescue nil
  puts Time.now.to_s
end
```

Console output:

```
2014-09-10 14:05:55 -0700
2014-09-11 14:05:55 -0700
2014-09-11 14:05:55 -0700
```

Errors raised in a `Timecop.return` block mean the previous time is never restored, undoing any freezes or travels. This PR simply adds an `ensure` statement in `Timecop#return` that ensures the current stack always gets restored, even when an error occurs in the `yield`.