### PR TITLE
Fix a bug wrt to datetime precision after travel

### DIFF
--- a/lib/timecop/time_stack_item.rb
+++ b/lib/timecop/time_stack_item.rb
@@ -75,12 +75,8 @@ class Timecop
 
       def datetime(datetime_klass = DateTime)
         if Float.method_defined?(:to_r)
-          if !sec.zero?
-            fractions_of_a_second = time.to_f % 1
-            datetime_klass.new(year, month, day, hour, min, (fractions_of_a_second + sec), utc_offset_to_rational(utc_offset))
-          else 
-            datetime_klass.new(year, month, day, hour, min, sec, utc_offset_to_rational(utc_offset))
-          end
+          fractions_of_a_second = time.to_f % 1
+          datetime_klass.new(year, month, day, hour, min, (fractions_of_a_second + sec), utc_offset_to_rational(utc_offset))
         else
           datetime_klass.new(year, month, day, hour, min, sec, utc_offset_to_rational(utc_offset))
         end

--- a/test/time_stack_item_test.rb
+++ b/test/time_stack_item_test.rb
@@ -269,7 +269,7 @@ class TestTimeStackItem < Minitest::Unit::TestCase
 
   def test_datetime_timezones
     dt = DateTime.new(2011,1,3,15,25,0,"-6")
-    Timecop.travel(dt) do
+    Timecop.freeze(dt) do
       now = DateTime.now
       assert_equal dt, now, "#{dt.to_f}, #{now.to_f}"
     end

--- a/test/timecop_test.rb
+++ b/test/timecop_test.rb
@@ -58,7 +58,10 @@ class TestTimecop < Minitest::Unit::TestCase
   def test_travel_does_not_reduce_precision_of_datetime
     # requires to_r on Float (>= 1.9)
     if Float.method_defined?(:to_r)
-      Timecop.travel(1)
+      Timecop.travel(Time.new(2014, 1, 1, 0, 0, 0))
+      assert DateTime.now != DateTime.now
+
+      Timecop.travel(Time.new(2014, 1, 1, 0, 0, 59))
       assert DateTime.now != DateTime.now
     end
   end


### PR DESCRIPTION
Note that the first comment fixes the test, but actually breaks the build. The second commit fixes things.