### PR TITLE
Timecop.freeze also works but it's not documented or explicitly tested

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -2,7 +2,7 @@
 
 Root: [![Build Status](https://secure.travis-ci.org/travisjeffery/timecop.png)](http://travis-ci.org/travisjeffery/timecop)
 
-This Fork: [![Build Status](https://travis-ci.org/txangel/timecop.svg)](https://github.com/txangel/timecop)
+This Fork: [![Build Status](https://travis-ci.org/txangel/timecop.svg)](https://travis-ci.org/txangel/timecop)
 
 ## DESCRIPTION
 

--- a/README.markdown
+++ b/README.markdown
@@ -1,6 +1,8 @@
 # timecop
 
-[![Build Status](https://secure.travis-ci.org/travisjeffery/timecop.png)](http://travis-ci.org/travisjeffery/timecop)
+Root: [![Build Status](https://secure.travis-ci.org/travisjeffery/timecop.png)](http://travis-ci.org/travisjeffery/timecop)
+
+This Fork: [![Build Status](https://travis-ci.org/txangel/timecop.svg)](https://github.com/txangel/timecop)
 
 ## DESCRIPTION
 

--- a/lib/timecop/timecop.rb
+++ b/lib/timecop/timecop.rb
@@ -31,6 +31,7 @@ class Timecop
     # 3. Timecop.freeze(date_inst)
     # 4. Timecop.freeze(offset_in_seconds)
     # 5. Timecop.freeze(year, month, day, hour=0, minute=0, second=0)
+    # 6. Timecop.freeze() # Defaults to Time.now
     #
     # When a block is also passed, Time.now, DateTime.now and Date.today are all reset to their
     # previous values after the block has finished executing.  This allows us to nest multiple

--- a/test/timecop_test.rb
+++ b/test/timecop_test.rb
@@ -212,7 +212,7 @@ class TestTimecop < Minitest::Unit::TestCase
       assert_equal t, Time.now
       Timecop.freeze do
         assert_equal t, Time.now
-        assert_equal Time.local(2008, 10, 10, 10, 10, 20), Time.now
+        assert_equal Time.local(2008, 10, 10, 10, 10, 10), Time.now
         assert_equal Date.new(2008, 10, 10), Date.today
       end
     end

--- a/test/timecop_test.rb
+++ b/test/timecop_test.rb
@@ -206,6 +206,20 @@ class TestTimecop < Minitest::Unit::TestCase
     assert Date.new(2008, 10, 10) != Date.today
   end
 
+  def test_freeze_without_arguments_instance_works_as_expected
+    t = Time.local(2008, 10, 10, 10, 10, 10)
+    Timecop.freeze(t) do
+      assert_equal t, Time.now
+      Timecop.freeze do
+        assert_equal t, Time.now
+        assert_equal Time.local(2008, 10, 10, 10, 10, 20), Time.now
+        assert_equal Date.new(2008, 10, 10), Date.today
+      end
+    end
+    assert t != Time.now
+  end
+
+
   def test_exception_thrown_in_freeze_block_properly_resets_time
     t = Time.local(2008, 10, 10, 10, 10, 10)
     begin


### PR DESCRIPTION
I suggest updating the comment and adding a simple test like the one below.

Else removing this statement https://github.com/travisjeffery/timecop/blob/master/lib/timecop/time_stack_item.rb#L109 if it should not be supported.

However I find `Timecop.freeze` to be a nice syntax.
![image](https://cloud.githubusercontent.com/assets/4802423/5124501/50f9ff4a-70b0-11e4-9d55-8a204ef33615.png)
