### PR TITLE
Eliminate ruby warnings

### DIFF
--- a/lib/timecop/time_extensions.rb
+++ b/lib/timecop/time_extensions.rb
@@ -63,13 +63,11 @@ class DateTime #:nodoc:
       mocked_time_stack_item.nil? ? nil : mocked_time_stack_item.datetime(self)
     end
 
-    def now_without_mock_time
-      Time.now_without_mock_time.to_datetime
-    end
-
     def now_with_mock_time
       mock_time || now_without_mock_time
     end
+
+    alias_method :now_without_mock_time, :now
 
     alias_method :now, :now_with_mock_time
   end

--- a/lib/timecop/time_stack_item.rb
+++ b/lib/timecop/time_stack_item.rb
@@ -6,6 +6,7 @@ class Timecop
 
       def initialize(mock_type, *args)
         raise "Unknown mock_type #{mock_type}" unless [:freeze, :travel, :scale].include?(mock_type)
+        @travel_offset  = @scaling_factor = nil
         @scaling_factor = args.shift if mock_type == :scale
         @mock_type      = mock_type
         @time           = parse_time(*args)
@@ -137,4 +138,4 @@ class Timecop
         Time.respond_to?(:zone) && Time.zone ? Time.zone : Time
       end
     end
-  end
+end

--- a/lib/timecop/timecop.rb
+++ b/lib/timecop/timecop.rb
@@ -107,7 +107,7 @@ class Timecop
     end
 
     def safe_mode?
-      false || @safe_mode
+      @safe_mode ||= false
     end
 
     private

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -2,6 +2,8 @@ require 'rubygems'
 require 'bundler/setup'
 require 'minitest/autorun'
 
+$VERBOSE = true # enable ruby warnings
+
 begin
   require 'mocha/setup'
 rescue LoadError


### PR DESCRIPTION
Eliminates various warnings issued by ruby in its verbose warning mode (`ruby -w`, or `$VERBOSE = true`, or `RSpec.config.warnings = true`).

This was an issue for me in an app that I'm testing using `RSpec.config.warnings = true` (as recommended by the default RSpec generator); there are only a few warnings due to Timecop, but they get repeated *many* times.