### PR TITLE
Fix a syntax error in the README

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -51,7 +51,8 @@ describe "some set of tests to mock" do
     Timecop.return
   end
 
-  it "should do blah blah blah" {}
+  it "should do blah blah blah" do
+  end
 end
 ```
 


### PR DESCRIPTION
`foo "bar" {}` is not parsed as `foo("bar") {}`, but as `foo("bar" {})`, which is invalid syntax.