### PR TITLE
add Timecop.frozen?

### DIFF
--- a/lib/timecop/timecop.rb
+++ b/lib/timecop/timecop.rb
@@ -111,6 +111,11 @@ class Timecop
       @safe_mode ||= false
     end
 
+    # Returns whether or not Timecop is currently frozen/travelled
+    def frozen?
+      !instance.instance_variable_get(:@_stack).empty?
+    end
+
     private
     def send_travel(mock_type, *args, &block)
       val = instance.send(:travel, mock_type, *args, &block)

--- a/test/timecop_test.rb
+++ b/test/timecop_test.rb
@@ -293,7 +293,7 @@ class TestTimecop < Minitest::Unit::TestCase
       end
     end
   end
-  
+
   def test_freeze_without_arguments_instance_works_as_expected
     t = Time.local(2008, 10, 10, 10, 10, 10)
     Timecop.freeze(t) do
@@ -517,6 +517,23 @@ class TestTimecop < Minitest::Unit::TestCase
     Timecop.freeze(Time.new(1984,2,28)) do
       assert_equal Date.strptime('1999-04-14'), Date.new(1999, 4, 14)
     end
+  end
+
+  def test_frozen_after_freeze
+    Timecop.freeze
+    assert Timecop.frozen?
+  end
+
+  def test_frozen_inside_freeze
+    Timecop.freeze do
+      assert Timecop.frozen?
+    end
+  end
+
+  def test_not_frozen_after_return
+    Timecop.freeze
+    Timecop.return
+    assert !Timecop.frozen?
   end
 
   private


### PR DESCRIPTION
This PR adds `Timecop.frozen?` which returns whether or not the cop has anything on its stack

This lets us add this to our global test teardown:

```rb
raise "BRR! IT'S COLD IN HERE!" if Timecop.frozen?
```