### PR TITLE
simplify test setup

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,14 +1,9 @@
-require 'rubygems'
 require 'bundler/setup'
 require 'minitest/autorun'
 
 $VERBOSE = true # enable ruby warnings
 
-begin
-  require 'mocha/setup'
-rescue LoadError
-  require 'mocha'
-end
+require 'mocha/setup'
 
 class Minitest::Unit::TestCase
   private

--- a/test/time_stack_item_test.rb
+++ b/test/time_stack_item_test.rb
@@ -1,6 +1,6 @@
 require 'date'
-require File.join(File.dirname(__FILE__), "test_helper")
-require File.join(File.dirname(__FILE__), '..', 'lib', 'timecop')
+require_relative "test_helper"
+require 'timecop'
 
 require 'active_support/all'
 

--- a/test/timecop_date_parse_test.rb
+++ b/test/timecop_date_parse_test.rb
@@ -1,5 +1,5 @@
-require File.join(File.dirname(__FILE__), "test_helper")
-require File.join(File.dirname(__FILE__), '..', 'lib', 'timecop')
+require_relative "test_helper"
+require 'timecop'
 
 class TestTimecop < Minitest::Unit::TestCase
   def setup

--- a/test/timecop_test.rb
+++ b/test/timecop_test.rb
@@ -1,5 +1,5 @@
-require File.join(File.dirname(__FILE__), "test_helper")
-require File.join(File.dirname(__FILE__), '..', 'lib', 'timecop')
+require_relative "test_helper"
+require 'timecop'
 
 class TestTimecop < Minitest::Unit::TestCase
   def teardown

--- a/test/timecop_with_active_support_test.rb
+++ b/test/timecop_with_active_support_test.rb
@@ -1,8 +1,10 @@
 require 'date'
+
+require 'bundler/setup'
 require 'active_support/all'
 
-require File.join(File.dirname(__FILE__), "test_helper")
-require File.join(File.dirname(__FILE__), '..', 'lib', 'timecop')
+require_relative "test_helper"
+require 'timecop'
 
 class TestTimecopWithActiveSupport < Minitest::Unit::TestCase
   def teardown

--- a/test/timecop_without_date_but_with_time_test.rb
+++ b/test/timecop_without_date_but_with_time_test.rb
@@ -1,10 +1,8 @@
-require File.join(File.dirname(__FILE__), "test_helper")
+require_relative "test_helper"
+require "time"
 
 class TestTimecopWithoutDateButWithTime < Minitest::Unit::TestCase
-  TIMECOP_LIB = File.join(File.dirname(__FILE__), '..', 'lib', 'timecop')
-
   def test_loads_properly_when_time_is_required_instead_of_date
-    require "time"
-    require TIMECOP_LIB
+    require 'timecop'
   end
 end

--- a/test/timecop_without_date_test.rb
+++ b/test/timecop_without_date_test.rb
@@ -1,5 +1,5 @@
-require File.join(File.dirname(__FILE__), "test_helper")
-require File.join(File.dirname(__FILE__), '..', 'lib', 'timecop')
+require_relative "test_helper"
+require 'timecop'
 
 class TestTimecopWithoutDate < Minitest::Unit::TestCase
 


### PR DESCRIPTION
 - reply on bundler/setup setting up the load paths
 - do not require rubygems, it is not recommended + unnecessary
 - simplify mocha require
 - enable running `ruby test/timecop_test.rb` without having to specify `-I.`
 - load bundler before loading activesupport in timecop_with_activesupport test so there will be no version conflict when run without bundle exec

@travisjeffery 