### PR TITLE
fix test/time_stack_item_test.rb failing in PDT

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -2,6 +2,7 @@ require 'bundler/setup'
 require 'minitest/autorun'
 
 $VERBOSE = true # enable ruby warnings
+ENV["TZ"] = "UTC"
 
 require 'mocha/setup'
 


### PR DESCRIPTION
@travisjeffery 

```
  1) Failure:
TestTimeStackItem#test_timezones_apply_dates [test/time_stack_item_test.rb:187]:
Expected: Thu, 03 Jan 2013
  Actual: Wed, 02 Jan 2013
```