### PR TITLE
Using Time.travel with a string should use Time.zone if available

### DIFF
--- a/lib/timecop/time_stack_item.rb
+++ b/lib/timecop/time_stack_item.rb
@@ -102,12 +102,12 @@ class Timecop
         elsif Object.const_defined?(:Date) && arg.is_a?(Date)
           time_klass.local(arg.year, arg.month, arg.day, 0, 0, 0)
         elsif args.empty? && arg.kind_of?(Integer)
-          Time.now + arg
+          time_klass.now + arg
         elsif arg.nil?
-          Time.now
+          time_klass.now
         else
           if arg.is_a?(String) && Time.respond_to?(:parse)
-            Time.parse(arg)
+            time_klass.parse(arg)
           else
             # we'll just assume it's a list of y/m/d/h/m/s
             year   = arg        || 2000

--- a/test/time_stack_item_test.rb
+++ b/test/time_stack_item_test.rb
@@ -179,6 +179,15 @@ class TestTimeStackItem < Minitest::Test
     end
   end
 
+  def test_timezones_with_parsed_string
+    Time.zone = "Europe/Zurich"
+    time_string = "2012-12-27 12:12"
+    expected_time = Time.zone.parse(time_string)
+    Timecop.freeze(time_string) do |frozen_time|
+      assert_equal expected_time, frozen_time
+    end
+  end
+
   def test_timezones_apply_dates
     Time.zone = "Central Time (US & Canada)"
     time = Time.zone.local(2013,1,3)


### PR DESCRIPTION
I found that if I use Time.travel (or Time.freeze) with a string representation of the time rather than an actual Time object, then the parse wouldn't make use of Time.zone.

i.e. 

``` Ruby
Time.zone = 'London'
Time.travel("2015-12-25 11:00") do
  # ruh roh, now I'm actually in New Zealand (my system time zone)
end
```

This pull request uses the handy time_klass method to see if the active support Time.zone is available, and uses that for parsing.
