### PR TITLE
Add support for Float arguments to Timecop.freeze, Timecop.travel

### DIFF
--- a/lib/timecop/time_stack_item.rb
+++ b/lib/timecop/time_stack_item.rb
@@ -101,7 +101,7 @@ class Timecop
           time_klass.at(arg.to_time.to_f).getlocal
         elsif Object.const_defined?(:Date) && arg.is_a?(Date)
           time_klass.local(arg.year, arg.month, arg.day, 0, 0, 0)
-        elsif args.empty? && arg.kind_of?(Integer)
+        elsif args.empty? && (arg.kind_of?(Integer) || arg.kind_of?(Float))
           Time.now + arg
         elsif arg.nil?
           Time.now

--- a/test/time_stack_item_test.rb
+++ b/test/time_stack_item_test.rb
@@ -87,6 +87,19 @@ class TestTimeStackItem < Minitest::Test
     assert_equal s,   stack_item.sec
   end
 
+  def test_new_with_float
+    t = Time.now
+    y, m, d, h, min, s = t.year, t.month, t.day, t.hour, t.min, t.sec
+    stack_item = Timecop::TimeStackItem.new(:freeze, 0.0)
+
+    assert_equal y,   stack_item.year
+    assert_equal m,   stack_item.month
+    assert_equal d,   stack_item.day
+    assert_equal h,   stack_item.hour
+    assert_equal min, stack_item.min
+    assert_equal s,   stack_item.sec
+  end
+
   def test_new_with_individual_arguments
     y, m, d, h, min, s = 2008, 10, 10, 10, 10, 10
     stack_item = Timecop::TimeStackItem.new(:freeze, y, m, d, h, min, s)


### PR DESCRIPTION
Allows Timecop to accept floats for the `.freeze` and `.travel` methods. 

Most common use case is probably in ActiveSupport's Time extensions (`1.year`, `3.5.hours`) which can return floats.

Includes tests.

Should fix issues https://github.com/travisjeffery/timecop/issues/145 and https://github.com/travisjeffery/timecop/issues/174.

:cactus: 