### PR TITLE
Thread safe time travel

### DIFF
--- a/lib/timecop/timecop.rb
+++ b/lib/timecop/timecop.rb
@@ -108,7 +108,28 @@ class Timecop
     end
 
     def safe_mode?
-      @safe_mode ||= false
+      !!@safe_mode
+    end
+
+    def thread_safe=(safe)
+      @thread_safe = safe
+    end
+
+    def thread_safe?
+      !!@thread_safe
+    end
+
+    alias __singleton_instance instance
+
+    def instance
+      if thread_safe?
+        instance = Thread.current[:timecop_instance]
+        return instance if instance
+        instance = Timecop.__singleton_instance
+        Thread.current[:timecop_instance] = instance
+      else
+        __singleton_instance
+      end
     end
 
     # Returns whether or not Timecop is currently frozen/travelled

--- a/test/timecop_thread_safe_test.rb
+++ b/test/timecop_thread_safe_test.rb
@@ -1,0 +1,20 @@
+require_relative "test_helper"
+require 'timecop'
+
+class TestTimecop < Minitest::Test
+  def teardown
+    Timecop.thread_safe = false
+    Thread.current[:timecop_instance] = nil
+  end
+
+  def test_thread_safe
+    Timecop.thread_safe = true
+    tc = Timecop.instance
+    assert_equal Thread.current[:timecop_instance], tc
+  end
+
+  def test_thread_unsafe
+    tc = Timecop.instance
+    assert_equal Thread.current[:timecop_instance], nil
+  end
+end


### PR DESCRIPTION
In order to make timecop work with multi-threaded applications such as puma server
we need to have timecop instance specific for each request/thread or threads will conflict with each other.
To make it work, we need to store timecop instance in thread variable
