### PR TITLE
Adhere to Ruby DateTime implementation

### DIFF
--- a/lib/timecop/time_extensions.rb
+++ b/lib/timecop/time_extensions.rb
@@ -98,7 +98,7 @@ class DateTime #:nodoc:
 
     def parse_with_mock_date(*args)
       str = args.first
-      if str && Date::WEEKDAYS.keys.include?(str.downcase)
+      if str && str.respond_to(:downcase) && Date::WEEKDAYS.keys.include?(str.downcase)
         offset = Date::WEEKDAYS[str.downcase] - DateTime.now.wday
 
         parsed_weekday =(DateTime.now + offset)

--- a/lib/timecop/time_extensions.rb
+++ b/lib/timecop/time_extensions.rb
@@ -98,7 +98,7 @@ class DateTime #:nodoc:
 
     def parse_with_mock_date(*args)
       str = args.first
-      if str && str.respond_to(:downcase) && Date::WEEKDAYS.keys.include?(str.downcase)
+      if str && str.respond_to?(:downcase) && Date::WEEKDAYS.keys.include?(str.downcase)
         offset = Date::WEEKDAYS[str.downcase] - DateTime.now.wday
 
         parsed_weekday =(DateTime.now + offset)

--- a/test/timecop_date_parse_test.rb
+++ b/test/timecop_date_parse_test.rb
@@ -81,6 +81,14 @@ class TestTimecop < Minitest::Test
     assert_equal DateTime.parse("2008-09-06", false), DateTime.parse('Saturday')
   end
 
+  def test_date_time_parse_with_array
+    assert_raises(TypeError) { DateTime.parse([]) }
+  end
+
+  def test_date_time_parse_with_hash
+    assert_raises(TypeError) { DateTime.parse({}) } 
+  end
+
   def test_datetime_parse_nil_raises_type_error
     assert_raises(TypeError) { DateTime.parse(nil) }
   end


### PR DESCRIPTION
`DateTime.parse([])` actually throws a `TypeError` in default Ruby, but a `NoMethodError` when timecop is required. This change fixes that difference.
