### PR TITLE
In safe mode, when already frozen, allow travelling with no block

### DIFF
--- a/lib/timecop/timecop.rb
+++ b/lib/timecop/timecop.rb
@@ -135,7 +135,7 @@ class Timecop
   end
 
   def travel(mock_type, *args, &block) #:nodoc:
-    raise SafeModeException if Timecop.safe_mode? && !block_given?
+    raise SafeModeException if !Timecop.frozen? && Timecop.safe_mode? && !block_given?
 
     stack_item = TimeStackItem.new(mock_type, *args)
 

--- a/test/timecop_test.rb
+++ b/test/timecop_test.rb
@@ -495,6 +495,14 @@ class TestTimecop < Minitest::Test
     end
   end
 
+  def test_no_raise_when_already_frozen_with_safe_mode_and_no_block
+    with_safe_mode do
+      Timecop.freeze {
+        Timecop.freeze
+      }
+    end
+  end
+
   def test_no_raise_when_safe_mode_and_block_used
     with_safe_mode do
       Timecop.freeze {}


### PR DESCRIPTION
It would be nice to be able to time-travel without a block, if time is already frozen.

Changes in response to: https://github.com/travisjeffery/timecop/issues/135