### PR TITLE
require rack < 2.0.0 for some ruby versions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ gemspec
 
 group :development do
   gem 'rake'
+  gem 'rack', '< 2.0.0', :platforms => [:ruby_19, :ruby_20, :ruby_21]
   gem 'jeweler'
   gem 'pry'
   gem 'mocha'


### PR DESCRIPTION
Prevent dependency on Ruby 2.2.2 when switching Ruby versions with rvm in Travis job.

As described in issue: https://github.com/travisjeffery/timecop/issues/193
