### PR TITLE
Date.strptime throws wrong message

### DIFF
--- a/lib/timecop/time_extensions.rb
+++ b/lib/timecop/time_extensions.rb
@@ -59,7 +59,12 @@ class Date #:nodoc:
           "supports Date::ITALY for the start argument."
       end
 
-      Time.strptime(str, fmt).to_date
+      begin
+        Time.strptime(str, fmt).to_date
+      rescue ArgumentError => error
+        raise unless error.message.include? 'invalid strptime format'
+        raise ArgumentError, 'invalid date'
+      end
     end
 
     alias_method :strptime, :strptime_with_mock_date

--- a/test/timecop_test.rb
+++ b/test/timecop_test.rb
@@ -519,6 +519,11 @@ class TestTimecop < Minitest::Test
     end
   end
 
+  def test_date_strptime_with_invalid_format
+    error = assert_raises(ArgumentError) { Date.strptime('', '%m/%d/%Y') }
+    assert_equal 'invalid date', error.message
+  end
+
   def test_frozen_after_freeze
     Timecop.freeze
     assert Timecop.frozen?


### PR DESCRIPTION
`Timecop` internally uses `Time.strptime` for mocking `Date.strptime`. This has an unfortunate consequence of throwing the wrong error message when date format is not valid. The different error message can produce subtle bugs. Consider you have the following code:
```
begin
  Date.strptime(param, '%m/%d/%Y')
rescue ArgumentError => error
  raise unless error.message.include? 'invalid date'
  # do something else to handle the invalid date
end
```
The code would work in dev/production environments, but not in test environment where `Timecop` is loaded. Changing `raise unless error.message.include? 'invalid date'` to `raise unless error.message.include? 'invalid strptime format'` would make it work in test environment, but not development/production. 

This pull requests fixes it so that raised error message is identical, whether `Timecop` is loaded or not.