### PR TITLE
Don't raise SafeModeException if block given previously up the stack

### DIFF
--- a/lib/timecop/timecop.rb
+++ b/lib/timecop/timecop.rb
@@ -132,10 +132,11 @@ class Timecop
 
   def initialize #:nodoc:
     @_stack = []
+    @_safe = nil
   end
 
   def travel(mock_type, *args, &block) #:nodoc:
-    raise SafeModeException if Timecop.safe_mode? && !block_given?
+    raise SafeModeException if Timecop.safe_mode? && !block_given? && !@_safe
 
     stack_item = TimeStackItem.new(mock_type, *args)
 
@@ -143,10 +144,13 @@ class Timecop
     @_stack << stack_item
 
     if block_given?
+      safe_backup = @_safe
+      @_safe = true
       begin
         yield stack_item.time
       ensure
         @_stack.replace stack_backup
+        @_safe = safe_backup
       end
     end
   end

--- a/test/timecop_test.rb
+++ b/test/timecop_test.rb
@@ -495,6 +495,18 @@ class TestTimecop < Minitest::Test
     end
   end
 
+  def test_raises_when_safe_mode_and_no_block_though_previously_block_given
+    Timecop.freeze do
+      Timecop.freeze
+    end
+
+    with_safe_mode do
+      assert_raises Timecop::SafeModeException do
+        Timecop.freeze
+      end
+    end
+  end
+
   def test_no_raise_when_safe_mode_and_block_used
     with_safe_mode do
       Timecop.freeze {}
@@ -504,6 +516,14 @@ class TestTimecop < Minitest::Test
   def test_no_raise_when_not_safe_mode_and_no_block
     with_safe_mode(false) do
       Timecop.freeze
+    end
+  end
+
+  def test_no_raise_when_safe_mode_and_no_block_and_in_block_context
+    with_safe_mode do
+      Timecop.freeze do
+        Timecop.freeze
+      end
     end
   end
 


### PR DESCRIPTION
Relating to https://github.com/travisjeffery/timecop/issues/135

This alters the definition of "safe mode"

Before
> When in safe mode disallow freeze/travel unless block is supplied

After
> When in safe mode disallow freeze/travel unless block is supplied OR safety is already ensured by a block supplied further up the stack
