### PR TITLE
Allow parsing of month/year dates without applying offset

### DIFF
--- a/lib/timecop/time_extensions.rb
+++ b/lib/timecop/time_extensions.rb
@@ -59,7 +59,7 @@ class Date #:nodoc:
       date_hash = Date._parse(*args)
 
       case
-      when date_hash[:year] && date_hash[:mon] && date_hash[:mday]
+      when date_hash[:year] && date_hash[:mon]
         parsed_date
       when date_hash[:mon] && date_hash[:mday]
         Date.new(mocked_time_stack_item.year, date_hash[:mon], date_hash[:mday])
@@ -107,7 +107,7 @@ class DateTime #:nodoc:
       date_hash = DateTime._parse(*args)
 
       case
-      when date_hash[:year] && date_hash[:mon] && date_hash[:mday]
+      when date_hash[:year] && date_hash[:mon]
         parsed_date
       when date_hash[:mon] && date_hash[:mday]
         DateTime.new(mocked_time_stack_item.year, date_hash[:mon], date_hash[:mday])

--- a/test/timecop_date_parse_shorcut_freeze_test.rb
+++ b/test/timecop_date_parse_shorcut_freeze_test.rb
@@ -60,6 +60,10 @@ class TestTimecop < Minitest::Test
     assert_equal Date.parse("2008-10-10"), Date.parse('Date 10/10')
   end
 
+  def test_date_parse_month_year
+    assert_equal Date.parse("2012-12-01"), Date.parse('DEC 2012')
+  end
+
   def test_date_parse_nil_raises_type_error
     assert_raises(TypeError) { Date.parse(nil) }
   end
@@ -111,6 +115,10 @@ class TestTimecop < Minitest::Test
 
   def test_date_time_parse_Date_10_slash_10
     assert_equal DateTime.parse("2008-10-10"), DateTime.parse('Date 10/10')
+  end
+
+  def test_date_time_parse_month_year
+    assert_equal DateTime.parse("2012-12-01"), Date.parse('DEC 2012')
   end
 
   def test_datetime_parse_nil_raises_type_error


### PR DESCRIPTION
Relax the check on incoming date_hash to return the unaltered
parsed_date if only year and month are supplied.

I submitted issue #205 for this.