### PR TITLE
Timecop#unfreeze - Add alias for Timecop#return

### DIFF
--- a/lib/timecop/timecop.rb
+++ b/lib/timecop/timecop.rb
@@ -93,6 +93,7 @@ class Timecop
         nil
       end
     end
+    alias :unfreeze :return
 
     def return_to_baseline
       instance.send(:return_to_baseline)

--- a/test/timecop_test.rb
+++ b/test/timecop_test.rb
@@ -37,6 +37,12 @@ class TestTimecop < Minitest::Test
     assert_nil Time.send(:mock_time)
   end
 
+  def test_freeze_then_unfreeze_unsets_mock_time
+    Timecop.freeze(1)
+    Timecop.unfreeze
+    assert_nil Time.send(:mock_time)
+  end
+
   def test_travel_then_return_unsets_mock_time
     Timecop.travel(1)
     Timecop.return


### PR DESCRIPTION
Hey

I was using Timecop recently and it was just weird for me that there is to unfreeze time I had to use return method. `unfreeze` was just more common sense in my opinion and more consistent with rest of API so I thought that maybe adding just alias would be nice 😄 