### PR TITLE
Fix parse_with_mock_date interfaces

### DIFF
--- a/lib/timecop/time_extensions.rb
+++ b/lib/timecop/time_extensions.rb
@@ -101,7 +101,6 @@ class DateTime #:nodoc:
     alias_method :now, :now_with_mock_time
 
     def parse_with_mock_date(*args)
-      date_hash = Date._parse(*args)
       parsed_date = parse_without_mock_date(*args)
       return parsed_date unless mocked_time_stack_item
       date_hash = DateTime._parse(*args)

--- a/lib/timecop/time_extensions.rb
+++ b/lib/timecop/time_extensions.rb
@@ -100,10 +100,10 @@ class DateTime #:nodoc:
 
     alias_method :now, :now_with_mock_time
 
-    def parse_with_mock_date(*args)
-      parsed_date = parse_without_mock_date(*args)
+    def parse_with_mock_date(str = '-4712-01-01T00:00:00+00:00', complete = true, start = Date::ITALY)
+      parsed_date = parse_without_mock_date(str, complete, start)
       return parsed_date unless mocked_time_stack_item
-      date_hash = DateTime._parse(*args)
+      date_hash = DateTime._parse(str, complete)
 
       case
       when date_hash[:year] && date_hash[:mon]

--- a/lib/timecop/time_extensions.rb
+++ b/lib/timecop/time_extensions.rb
@@ -53,10 +53,10 @@ class Date #:nodoc:
 
     alias_method :strptime, :strptime_with_mock_date
 
-    def parse_with_mock_date(*args)
-      parsed_date = parse_without_mock_date(*args)
+    def parse_with_mock_date(str = '-4712-01-01', complete = true, start = Date::ITALY)
+      parsed_date = parse_without_mock_date(str, complete, start)
       return parsed_date unless mocked_time_stack_item
-      date_hash = Date._parse(*args)
+      date_hash = Date._parse(str, complete)
 
       case
       when date_hash[:year] && date_hash[:mon]

--- a/test/timecop_test.rb
+++ b/test/timecop_test.rb
@@ -573,6 +573,12 @@ class TestTimecop < Minitest::Test
     Timecop.thread_safe = false
   end
 
+  def test_date_parse_interface
+    t = Date.parse_without_mock_date('-4712-01-01', true, Date::ITALY)
+    Timecop.freeze
+    assert_equal t, Date.parse('-4712-01-01', true, Date::ITALY)
+  end
+
   private
 
   def with_safe_mode(enabled=true)

--- a/test/timecop_test.rb
+++ b/test/timecop_test.rb
@@ -579,6 +579,12 @@ class TestTimecop < Minitest::Test
     assert_equal t, Date.parse('-4712-01-01', true, Date::ITALY)
   end
 
+  def test_datetime_parse_interface
+    t = DateTime.parse_without_mock_date('-4712-01-01T00:0:00+00:00', true, Date::ITALY)
+    Timecop.freeze
+    assert_equal t, DateTime.parse('-4712-01-01T00:0:00+00:00', true, Date::ITALY)
+  end
+
   private
 
   def with_safe_mode(enabled=true)


### PR DESCRIPTION
An ArgumentError occurs in Date.parse_with_mock_date and DateTime.parse_with_mock_date when three arguments are received using Timecop.freeze.
```
Timecop.freeze
Date.parse('-4712-01-01', true, Date::ITALY)
```
```
  1) Error:
TestTimecop#test_datetime_parse_interface:
ArgumentError: wrong number of arguments (given 3, expected 1..2)
    /home/vagrant/workspace/timecop/lib/timecop/time_extensions.rb:104:in `_parse'
    /home/vagrant/workspace/timecop/lib/timecop/time_extensions.rb:104:in `parse_with_mock_date'
    test/timecop_test.rb:585:in `test_datetime_parse_interface'
```

This pull request is a modification to match the original interface.