### PR TITLE
Fix minitest DEPRECATED

### DIFF
--- a/test/time_stack_item_test.rb
+++ b/test/time_stack_item_test.rb
@@ -181,7 +181,7 @@ class TestTimeStackItem < Minitest::Test
     t = Time.local(2009, 10, 1, 0, 0, 30)
     tsi = Timecop::TimeStackItem.new(:freeze, t)
 
-    assert_equal nil, tsi.send(:travel_offset)
+    assert_nil tsi.send(:travel_offset)
   end
 
   def test_timezones


### PR DESCRIPTION
This PR fix the following deprecation.

```
DEPRECATED: Use assert_nil if expecting nil from test/time_stack_item_test.rb:184. This will fail in M
initest 6.
```