### PR TITLE
Return to previous date after block when in threadsafe mode

### DIFF
--- a/lib/timecop/timecop.rb
+++ b/lib/timecop/timecop.rb
@@ -200,7 +200,7 @@ class Timecop
       begin
         yield stack_item.time
       ensure
-        @stack.replace stack_backup
+        stack.replace stack_backup
         @safe = safe_backup
       end
     end

--- a/test/timecop_test.rb
+++ b/test/timecop_test.rb
@@ -556,7 +556,7 @@ class TestTimecop < Minitest::Test
     assert !Timecop.frozen?
   end
 
-  def test_thread_safe_timecop
+  def test_thread_safe_timecop_in_parallel
     Timecop.thread_safe = true
     date = Time.local(2011, 01, 02)
     thread = Thread.new do
@@ -569,6 +569,16 @@ class TestTimecop < Minitest::Test
     sleep 0.25
     assert Time.now != date
     thread.join
+  ensure
+    Timecop.thread_safe = false
+  end
+
+  def test_thread_safe_timecop_returns_after_block
+    Timecop.thread_safe = true
+    date = Time.local(2017, 10, 8)
+
+    Timecop.freeze(date) { }
+    assert Time.now != date
   ensure
     Timecop.thread_safe = false
   end


### PR DESCRIPTION
The [`thread_safe` option](https://github.com/travisjeffery/timecop/pull/184) introduced to Timecop `v0.9.0` (and still present in `v0.9.1`) contains a major bug: The time is not automatically returned to its original state, when `Timecop.freeze` or `Timecop.travel` are called *with a block*.

The original PR for the feature actually worked fine, but was broken by [this separate commit line](https://github.com/travisjeffery/timecop/commit/e1eb6789d8df873d7dd75526dafc7655627bf1ba#diff-e2a91a7e1d108ef45b81d12313b150faR203), in [this PR](https://github.com/travisjeffery/timecop/pull/202).

Minimal reproduction example (as seen from the test in this PR):

    Timecop.thread_safe = true
    date = Time.local(2017, 10, 8)

    Timecop.freeze(date) { }
    puts Time.now  # => 2017-10-08 00:00:00 +0100

This bug *only* occurs in threadsafe mode.

The issue stems from a 1-character mistake: using `@stack` instead of `stack`. The latter calls [this method](https://github.com/travisjeffery/timecop/blob/68b033922edb1d4291cd69b115f881e0aa09367e/lib/timecop/timecop.rb#L157-L164):

    def stack
      if @thread_safe
        Thread.current[:timecop_stack] ||= []
        Thread.current[:timecop_stack]
      else
        @stack
      end
    end

When `thread_safe` mode is enabled, `@stack` remains an empty array - therefore the original time was not being returned to.