### PR TITLE
Raise an exception if this arg looks like a timestamp

### DIFF
--- a/lib/timecop/time_stack_item.rb
+++ b/lib/timecop/time_stack_item.rb
@@ -106,6 +106,9 @@ class Timecop
         elsif Object.const_defined?(:Date) && arg.is_a?(Date)
           time_klass.local(arg.year, arg.month, arg.day, 0, 0, 0)
         elsif args.empty? && (arg.kind_of?(Integer) || arg.kind_of?(Float))
+          if arg > 1300000000
+            raise "Please pass an offset to this method instead of a timestamp"
+          end
           time_klass.now + arg
         elsif arg.nil?
           time_klass.now


### PR DESCRIPTION
In the case where someone calls `Timecop.freeze(some_timestamp)`, they probably meant to freeze _at_ the provided timestamp, instead of that many seconds in the future.

I don't think I'd want to ship this PR, but can massage this PR into whichever of these you prefer:
1. `if arg > k`, using that timestamp
1. `if arg > k`, materializing an exception that can be caught
1. Something else?

---------------------

##### `k`

I chose 1300000000 somewhat arbitrarily. Happy to change it to something like `1000000000` instead.

##### Tests

Happy to write tests once you let me know which outcome you prefer.