### PR TITLE
store the time so that no time can pass in the call to datetime

### DIFF
--- a/lib/timecop/time_stack_item.rb
+++ b/lib/timecop/time_stack_item.rb
@@ -79,11 +79,24 @@ class Timecop
       end
 
       def datetime(datetime_klass = DateTime)
+        current_time = time
         if Float.method_defined?(:to_r)
-          fractions_of_a_second = time.to_f % 1
-          datetime_klass.new(year, month, day, hour, min, (fractions_of_a_second + sec), utc_offset_to_rational(utc_offset))
+          fractions_of_a_second = current_time.to_f % 1
+          datetime_klass.new(current_time.year,
+                             current_time.month,
+                             current_time.day,
+                             current_time.hour,
+                             current_time.min,
+                             (fractions_of_a_second + current_time.sec),
+                             utc_offset_to_rational(current_time.utc_offset))
         else
-          datetime_klass.new(year, month, day, hour, min, sec, utc_offset_to_rational(utc_offset))
+          datetime_klass.new(current_time.year,
+                             current_time.month,
+                             current_time.day,
+                             current_time.hour,
+                             current_time.min,
+                             current_time.sec,
+                             utc_offset_to_rational(current_time.utc_offset))
         end
       end
 


### PR DESCRIPTION
Hi,

Seems like a very small change, but it is very important that _no_ time can pass in the datetime implementation. This can cause weird jumps in time when the fractions of a second is very close to 1 (like 0.9999). As during the call enough time has passed to get into the next second once you get to the call to `#sec`.



