### PR TITLE
Date.today uses system time which is usually utc.

### DIFF
--- a/lib/timecop/time_stack_item.rb
+++ b/lib/timecop/time_stack_item.rb
@@ -75,7 +75,11 @@ class Timecop
       end
 
       def date(date_klass = Date)
-        date_klass.jd(time.__send__(:to_date).jd)
+        if Time.respond_to?(:zone_default)
+          date_klass.jd(time.__send__(:in_time_zone, Time.zone_default).to_date.jd)
+        else
+          date_klass.jd(time.__send__(:utc).to_date.jd)
+        end
       end
 
       def datetime(datetime_klass = DateTime)


### PR DESCRIPTION
within timecop Date.today was acting like Date.current and making it impossible
to track down issues between Date.today and Date.current

due to Date.today using system timezone and ignoring Time.zone
Date.today can equal Date.tomorrow with -tz offset
Date.today can equal Date.yesterday with +tz offset

