### PR TITLE
Update date parsing tests to assert correct exception type raised.

### DIFF
--- a/test/timecop_date_parse_test.rb
+++ b/test/timecop_date_parse_test.rb
@@ -45,8 +45,7 @@ class TestTimecop < Minitest::Test
   end
 
   def test_date_parse_non_string_raises_expected_error
-    expected_error = jruby? ? NoMethodError : TypeError
-    assert_raises(expected_error) { Date.parse(Object.new) }
+    assert_raises(TypeError) { Date.parse(Object.new) }
   end
 
   def test_date_parse_nil_raises_type_error
@@ -87,8 +86,7 @@ class TestTimecop < Minitest::Test
   end
 
   def test_date_time_parse_non_string_raises_expected_error
-    expected_error = jruby? ? NoMethodError : TypeError
-    assert_raises(expected_error) { DateTime.parse(Object.new) }
+    assert_raises(TypeError) { DateTime.parse(Object.new) }
   end
 
   def test_date_time_parse_nil_raises_type_error


### PR DESCRIPTION
JRuby 9.2.8.0 changed the exception type it raises in Date._parse for
unexpected input types.
https://github.com/jruby/jruby/commit/a6dad4b29ac656ce38212c4488f76492bc51d41c

This should resolve the two remaining test failures in Travis.