### PR TITLE
CI: Use jruby-9.2.11.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,6 @@ rvm:
   - 2.1
   - 2.0
   - 1.9.3
-  - jruby-9.2.8.0
+  - jruby-9.2.9.0
 jdk:
   - openjdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,6 @@ rvm:
   - 2.1
   - 2.0
   - 1.9.3
-  - jruby-9.2.9.0
+  - jruby-9.2.11.1
 jdk:
   - openjdk8


### PR DESCRIPTION
This PR updates the CI matrix to use latest JRuby, **9.2.11.1**.

[JRuby 9.2.11.1 release blog post](https://www.jruby.org/2020/03/25/jruby-9-2-11-1.html)