### PR TITLE
Remove rubyforge_project from gemspec.

### DIFF
--- a/timecop.gemspec
+++ b/timecop.gemspec
@@ -36,7 +36,6 @@ Gem::Specification.new do |s|
   s.homepage = %q{https://github.com/travisjeffery/timecop}
   s.rdoc_options = ["--charset=UTF-8"]
   s.require_paths = ["lib"]
-  s.rubyforge_project = %q{timecop}
   s.rubygems_version = %q{1.3.7}
   s.summary = %q{A gem providing "time travel" and "time freezing" capabilities, making it dead simple to test time-dependent code.  It provides a unified method to mock Time.now, Date.today, and DateTime.now in a single call.}
   s.license = "MIT"


### PR DESCRIPTION
Rubyforge is long gone. Leaving this in the specification causes a warning during installation with Rubygems 3.1+.