### PR TITLE
Fix testing timezone dates

### DIFF
--- a/test/time_stack_item_test.rb
+++ b/test/time_stack_item_test.rb
@@ -206,7 +206,7 @@ class TestTimeStackItem < Minitest::Test
     time = Time.zone.local(2013,1,3)
 
     Timecop.freeze(time) do
-      assert_equal time.to_date, Time.now.to_date
+      assert_equal time.to_date, Time.zone.now.to_date
     end
   end
 


### PR DESCRIPTION
The test_timezones_apply_dates test actually fails to test
timezones. It is comparing the local time with the time zone
specific time. Therefore the test actually only "passes" if the
time zone is to the "west" of the local time zone. A person in
the America/Los_Angeles time zone will receive a failure when
running the current test as the Central Time zone is to the "east".

Change the test to use Time.zone.now for the comparison date