### PR TITLE
TimeStackItemTest#test_timezones_apply_dates failing when my system timezone is pacific time

### DIFF
--- a/test/time_stack_item_test.rb
+++ b/test/time_stack_item_test.rb
@@ -206,7 +206,7 @@ class TestTimeStackItem < Minitest::Test
     time = Time.zone.local(2013,1,3)
 
     Timecop.freeze(time) do
-      assert_equal time.to_date, Time.now.to_date
+      assert_equal time.to_date, Time.now.in_time_zone("Central Time (US & Canada)").to_date
     end
   end
 


### PR DESCRIPTION
I was trying to run tests with the latest code and was seeing:

```
  1) Failure:
TestTimeStackItem#test_timezones_apply_dates [test/time_stack_item_test.rb:211]:
Expected: Thu, 03 Jan 2013
  Actual: Wed, 02 Jan 2013

```

I dug in and realized the time yielded by timecop freeze block is in "Central Time (US & Canada)" as specified in the test, but the Time.now frozen time from the assertion comes back in my system timezone. They are the same time, but the conversion to date will destroy the proper equivalence since that requires the full timezone data. 

The fix here is just to convert the Time.now timezone to the same timezone before comparison.

I guess this test would never fail if your system time was US Central time or east of there. Maybe nobody on the west coast is running these tests?