### PR TITLE
Fix strptime without day

### DIFF
--- a/lib/timecop/time_extensions.rb
+++ b/lib/timecop/time_extensions.rb
@@ -57,7 +57,7 @@ class Date #:nodoc:
       elsif d[:wday]
         Date.new(year, mon, now.mday) + (d[:wday] - now.wday)
       else
-        Date.new(year, mon, now.mday)
+        Date.new(year, mon)
       end
     end
 

--- a/test/timecop_test.rb
+++ b/test/timecop_test.rb
@@ -552,7 +552,7 @@ class TestTimecop < Minitest::Test
     end
   end
 
-  def test_date_strptime_without_day_of_week
+  def test_date_strptime_without_day
     Timecop.freeze(Time.new(1984,2,28)) do
       assert_equal Date.strptime('1999-04', '%Y-%m'), Date.new(1999, 4, 1)
     end

--- a/test/timecop_test.rb
+++ b/test/timecop_test.rb
@@ -552,6 +552,12 @@ class TestTimecop < Minitest::Test
     end
   end
 
+  def test_date_strptime_without_day_of_week
+    Timecop.freeze(Time.new(1984,2,28)) do
+      assert_equal Date.strptime('1999-04', '%Y-%m'), Date.new(1999, 4, 1)
+    end
+  end
+
   def test_date_strptime_with_invalid_date
     begin
       Date.strptime('', '%Y-%m-%d')


### PR DESCRIPTION
## Why

When calling the original `Date.strptime` without a day, the day is set to `1`. Timecop should probably not change that behavior.

```ruby
irb(main):002:0> require "date"
=> true
irb(main):003:0> Date.strptime('1999-04', '%Y-%m')
=> #<Date: 1999-04-01 ((2451270j,0s,0n),+0s,2299161j)>
irb(main):004:0> Date.new(1999, 4)
=> #<Date: 1999-04-01 ((2451270j,0s,0n),+0s,2299161j)>
```

## What

In this PR I added a small test case for parsing a Date without a "day", and expect the day to be `1`; In order to make this spec pass, I change the implementation of `strptime_with_mock_date` to not specify the "day" of the created date to be the "current day" when no specific day is provided, but to default to the first day of the month.