### PR TITLE
Fix date parse not working for dates with year and week. Bug 222 fix

### DIFF
--- a/lib/timecop/time_extensions.rb
+++ b/lib/timecop/time_extensions.rb
@@ -75,6 +75,8 @@ class Date #:nodoc:
         Date.new(mocked_time_stack_item.year, date_hash[:mon], date_hash[:mday])
       when date_hash[:wday]
         closest_wday(date_hash[:wday])
+      when date_hash[:cwyear] && date_hash[:cweek]
+        Date.commercial(date_hash[:cwyear], date_hash[:cweek])
       else
         parsed_date + mocked_time_stack_item.travel_offset_days
       end

--- a/test/date_parse_scenarios.rb
+++ b/test/date_parse_scenarios.rb
@@ -60,6 +60,14 @@ module DateParseScenarios
     assert_equal Date.parse("2012-12-01"), Date.parse('DEC 2012')
   end
 
+  def test_date_parse_month_year
+    assert_equal Date.parse("2012-12-01"), Date.parse('DEC 2012')
+  end
+
+  def test_date_parse_with_commercial_week_date
+    assert_equal Date.new(1984, 2, 27), Date.parse('1984-W09')
+  end
+
   def test_date_parse_nil_raises_type_error
     assert_raises(TypeError) { Date.parse(nil) }
   end


### PR DESCRIPTION
This is a fix for https://github.com/travisjeffery/timecop/issues/222