### PR TITLE
Refactor the strptime tests into their own tests similar to the parse…

### DIFF
--- a/test/date_strptime_scenarios.rb
+++ b/test/date_strptime_scenarios.rb
@@ -1,0 +1,29 @@
+module DateStrptimeScenarios
+
+  def test_date_strptime_without_year
+    assert_equal Date.strptime('04-14', '%m-%d'), Date.new(1984, 4, 14)
+  end
+
+  def test_date_strptime_without_day
+    assert_equal Date.strptime('1999-04', '%Y-%m'), Date.new(1999, 4, 1)
+  end
+
+  def test_date_strptime_without_specifying_format
+    assert_equal Date.strptime('1999-04-14'), Date.new(1999, 4, 14)
+  end
+
+  def test_date_strptime_with_day_of_week
+    assert_equal Date.strptime('Thursday', '%A'), Date.new(1984, 3, 1)
+    assert_equal Date.strptime('Monday', '%A'), Date.new(1984, 2, 27)
+  end
+
+  def test_date_strptime_with_invalid_date
+    assert_raises(ArgumentError) { Date.strptime('', '%Y-%m-%d') }
+  end
+
+  def test_ancient_strptime
+    ancient = Date.strptime('11-01-08', '%Y-%m-%d').strftime
+    assert_equal '0011-01-08', ancient # Failed before fix to strptime_with_mock_date
+  end
+
+end

--- a/test/timecop_date_strptime_freeze_test.rb
+++ b/test/timecop_date_strptime_freeze_test.rb
@@ -1,0 +1,18 @@
+require_relative "test_helper"
+require 'timecop'
+require_relative 'date_strptime_scenarios'
+
+class TestTimecop < Minitest::Test
+  def setup
+    t = Time.local(1984,2,28)
+    Timecop.freeze(t)
+  end
+
+  def teardown
+    Timecop.return
+  end
+
+  # Test for Date
+  include DateStrptimeScenarios
+
+end

--- a/test/timecop_date_strptime_travel_test.rb
+++ b/test/timecop_date_strptime_travel_test.rb
@@ -1,0 +1,18 @@
+require_relative "test_helper"
+require 'timecop'
+require_relative 'date_strptime_scenarios'
+
+class TestTimecop < Minitest::Test
+  def setup
+    t = Time.local(1984,2,28)
+    Timecop.travel(t)
+  end
+
+  def teardown
+    Timecop.return
+  end
+
+  # Test for Date
+  include DateStrptimeScenarios
+
+end

--- a/test/timecop_test.rb
+++ b/test/timecop_test.rb
@@ -533,44 +533,6 @@ class TestTimecop < Minitest::Test
     end
   end
 
-  def test_date_strptime_without_year
-    Timecop.freeze(Time.new(1984,2,28)) do
-      assert_equal Date.strptime('04-14', '%m-%d'), Date.new(1984, 4, 14)
-    end
-  end
-
-  def test_date_strptime_without_specifying_format
-    Timecop.freeze(Time.new(1984,2,28)) do
-      assert_equal Date.strptime('1999-04-14'), Date.new(1999, 4, 14)
-    end
-  end
-
-  def test_date_strptime_with_day_of_week
-    Timecop.freeze(Time.new(1984,2,28)) do
-      assert_equal Date.strptime('Thursday', '%A'), Date.new(1984, 3, 1)
-      assert_equal Date.strptime('Monday', '%A'), Date.new(1984, 2, 27)
-    end
-  end
-
-  def test_date_strptime_without_day
-    Timecop.freeze(Time.new(1984,2,28)) do
-      assert_equal Date.strptime('1999-04', '%Y-%m'), Date.new(1999, 4, 1)
-    end
-  end
-
-  def test_date_strptime_with_invalid_date
-    begin
-      Date.strptime('', '%Y-%m-%d')
-    rescue ArgumentError => e
-      assert_equal 'invalid date', e.message
-    end
-  end
-
-  def test_ancient_strptime
-    ancient = Date.strptime('11-01-08', '%Y-%m-%d').strftime
-    assert_equal '0011-01-08', ancient # Failed before fix to strptime_with_mock_date
-  end
-
   def test_frozen_after_freeze
     Timecop.freeze
     assert Timecop.frozen?


### PR DESCRIPTION
… tests. This is to support having a lot more coverage to this specific code. There are a lot of bugs in the backlog around this.