### PR TITLE
Include more date strptime test scenarios

### DIFF
--- a/test/date_strptime_scenarios.rb
+++ b/test/date_strptime_scenarios.rb
@@ -67,4 +67,25 @@ module DateStrptimeScenarios
 
     end
   end
+
+  def test_strptime_raises_when_unparsable
+    assert_raises(ArgumentError) do
+      Date.strptime('')
+    end
+    assert_raises(ArgumentError) do
+      Date.strptime('2001-02-29', '%F')
+    end
+    assert_raises(ArgumentError) do
+      Date.strptime('01-31-2011', '%m/%d/%Y')
+    end
+  end
+
+  def test_strptime_of_time_string_raises
+    #TODO: this is a bug
+    skip("TODO: broken contract")
+    assert_raises(ArgumentError) do
+      Date.strptime('23:55', '%H:%M')
+    end
+  end
+
 end

--- a/test/date_strptime_scenarios.rb
+++ b/test/date_strptime_scenarios.rb
@@ -1,5 +1,6 @@
 module DateStrptimeScenarios
 
+  #calling freeze and travel tests are making the date Time.local(1984,2,28)
   def test_date_strptime_without_year
     assert_equal Date.strptime('04-14', '%m-%d'), Date.new(1984, 4, 14)
   end
@@ -26,4 +27,44 @@ module DateStrptimeScenarios
     assert_equal '0011-01-08', ancient # Failed before fix to strptime_with_mock_date
   end
 
+  def test_strptime_defaults_correctly
+    assert_equal(Date.new, Date.strptime)
+  end
+
+  def test_strptime_from_date_to_s
+    d = Date.new(1984, 3, 1)
+    assert_equal(d, Date.strptime(d.to_s))
+  end
+
+  def test_strptime_converts_back_and_forth_between_date_and_string_for_many_formats_every_day_of_the_year
+    (Date.new(2006,6,1)..Date.new(2007,6,1)).each do |d|
+      [
+        '%Y %m %d',
+        '%C %y %m %d',
+
+        #TODO Support these formats
+        # '%Y %j',
+        # '%C %y %j',
+
+        # '%G %V %w',
+        # '%G %V %u',
+        # '%C %g %V %w',
+        # '%C %g %V %u',
+
+        # '%Y %U %w',
+        # '%Y %U %u',
+        # '%Y %W %w',
+        # '%Y %W %u',
+        # '%C %y %U %w',
+        # '%C %y %U %u',
+        # '%C %y %W %w',
+        # '%C %y %W %u',
+      ].each do |fmt|
+        s = d.strftime(fmt)
+        d2 = Date.strptime(s, fmt)
+        assert_equal(d, d2, [fmt, d.to_s, d2.to_s].inspect)
+      end
+
+    end
+  end
 end


### PR DESCRIPTION
This PR includes some new Date::strptime tests. Please note that i have commented out or skipped the tests that are failing. One step towards a better strptime implementation will be getting all these passing. They are inspired by the jruby test suite for Date. A lot of these use strftime for a given date, and then expect strptime to convert that string back into the original date. Our strptime doesn't work for a bunch of the formats.

Another thing that I am thinking about is that we are monkeypatching strptime, and delegating to _strptime... This might be a problem. Anyone using _strptime in their codebase will be confused since that won't adhere to the frozen date. I'm not really sure we're on the right track with our implementation.