### PR TITLE
Use Github Actions for CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,0 +1,35 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby:
+          - head
+          - '3.0'
+          - '2.7'
+          - '2.6'
+          - '2.5'
+          - '2.4'
+          - '2.3'
+          - '2.2'
+          - '2.1'
+          - jruby
+    continue-on-error: ${{ matrix.ruby == 'head' }}
+    name: Ruby ${{ matrix.ruby }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+      - run: |
+          bundle exec rake


### PR DESCRIPTION
Also tests against `ruby-head` and fixes a failure on it.

The `ruby/setup-ruby` action doesn't support Ruby 1.9 or 2.0, so dropping those. If support is still necessary, I can explore workarounds.

Sample build: https://github.com/mlarraz/timecop/actions/runs/496778019