### PR TITLE
Better: Add ruby 3.1 compatibility.

### DIFF
--- a/lib/timecop/time_extensions.rb
+++ b/lib/timecop/time_extensions.rb
@@ -10,16 +10,24 @@ class Time #:nodoc:
 
     alias_method :now_without_mock_time, :now
 
-    def now_with_mock_time
-      mock_time || now_without_mock_time
+    def now_with_mock_time(*args)
+      mock_time || now_without_mock_time(*args)
     end
 
     alias_method :now, :now_with_mock_time
 
     alias_method :new_without_mock_time, :new
 
-    def new_with_mock_time(*args)
-      args.size <= 0 ? now : new_without_mock_time(*args)
+    def new_with_mock_time(*args, **kwargs)
+      if args.size <= 0
+        now(*args)
+      else
+        if kwargs == {}
+          new_without_mock_time(*args)
+        else
+          new_without_mock_time(*args, **kwargs)
+        end
+      end
     end
 
     alias_method :new, :new_with_mock_time


### PR DESCRIPTION
In https://github.com/ylecuyer/puma-status I had a red build because timecop isn't yet compatible with ruby 3.1

<img src="https://user-images.githubusercontent.com/1866809/106370923-39efec80-635f-11eb-8f93-b1a0b7d7df14.png" height="250px" />

```
Run bundle exec rspec
/home/runner/.rubies/ruby-head/lib/ruby/gems/3.1.0/gems/bundler-1.17.3/lib/bundler/shared_helpers.rb:29: warning: Pathname#untaint is deprecated and will be removed in Ruby 3.2.
/home/runner/.rubies/ruby-head/lib/ruby/gems/3.1.0/gems/bundler-1.17.3/lib/bundler/shared_helpers.rb:118: warning: Pathname#untaint is deprecated and will be removed in Ruby 3.2.
/home/runner/.rubies/ruby-head/lib/ruby/gems/3.1.0/gems/bundler-1.17.3/lib/bundler/shared_helpers.rb:118: warning: Pathname#untaint is deprecated and will be removed in Ruby 3.2.
/home/runner/.rubies/ruby-head/lib/ruby/gems/3.1.0/gems/bundler-1.17.3/lib/bundler/shared_helpers.rb:35: warning: Pathname#untaint is deprecated and will be removed in Ruby 3.2.
/home/runner/.rubies/ruby-head/lib/ruby/gems/3.1.0/gems/bundler-1.17.3/lib/bundler/shared_helpers.rb:35: warning: Pathname#untaint is deprecated and will be removed in Ruby 3.2.
/home/runner/.rubies/ruby-head/lib/ruby/gems/3.1.0/gems/bundler-1.17.3/lib/bundler/shared_helpers.rb:44: warning: Pathname#untaint is deprecated and will be removed in Ruby 3.2.
/home/runner/.rubies/ruby-head/lib/ruby/gems/3.1.0/gems/bundler-1.17.3/lib/bundler/shared_helpers.rb:118: warning: Pathname#untaint is deprecated and will be removed in Ruby 3.2.
TypeError: no implicit conversion of Hash into Integer
bundler: failed to load command: rspec (/home/runner/.rubies/ruby-head/bin/rspec)
  <internal:timev>:123:in `initialize'
  /home/runner/.rubies/ruby-head/lib/ruby/gems/3.1.0/gems/timecop-0.9.1/lib/timecop/time_extensions.rb:22:in `new'
  /home/runner/.rubies/ruby-head/lib/ruby/gems/3.1.0/gems/timecop-0.9.1/lib/timecop/time_extensions.rb:22:in `new_with_mock_time'
  <internal:timev>:10:in `now'
  /home/runner/.rubies/ruby-head/lib/ruby/gems/3.1.0/gems/rspec-core-3.9.1/lib/rspec/core/reporter.rb:89:in `start'
  /home/runner/.rubies/ruby-head/lib/ruby/gems/3.1.0/gems/rspec-core-3.9.1/lib/rspec/core/reporter.rb:72:in `report'
  /home/runner/.rubies/ruby-head/lib/ruby/gems/3.1.0/gems/rspec-core-3.9.1/lib/rspec/core/runner.rb:115:in `run_specs'
  /home/runner/.rubies/ruby-head/lib/ruby/gems/3.1.0/gems/rspec-core-3.9.1/lib/rspec/core/runner.rb:89:in `run'
  /home/runner/.rubies/ruby-head/lib/ruby/gems/3.1.0/gems/rspec-core-3.9.1/lib/rspec/core/runner.rb:71:in `run'
  /home/runner/.rubies/ruby-head/lib/ruby/gems/3.1.0/gems/rspec-core-3.9.1/lib/rspec/core/runner.rb:45:in `invoke'
  /home/runner/.rubies/ruby-head/lib/ruby/gems/3.1.0/gems/rspec-core-3.9.1/exe/rspec:4:in `<top (required)>'
  /home/runner/.rubies/ruby-head/bin/rspec:23:in `load'
  /home/runner/.rubies/ruby-head/bin/rspec:23:in `<top (required)>'
Error: Process completed with exit code 1.
```
This is because of this new change in ruby 3.1: https://bugs.ruby-lang.org/issues/17485

This PR adds the support for it