### PR TITLE
Add dependabot configuration file

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# Set update schedule for GitHub Actions
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: bundler
+    directory: "/"
+    schedule:
+      interval: weekly


### PR DESCRIPTION
With this configuration file dependanbot will create PRs when a github or ruby gem dependency is out of date (see https://docs.github.com/en/github/administering-a-repository/configuration-options-for-dependency-updates)