### PR TITLE
Add support for ruby-head (3.1)

### DIFF
--- a/lib/timecop/time_extensions.rb
+++ b/lib/timecop/time_extensions.rb
@@ -22,6 +22,8 @@ class Time #:nodoc:
       args.size <= 0 ? now : new_without_mock_time(*args)
     end
 
+    ruby2_keywords :new_with_mock_time if Module.private_method_defined?(:ruby2_keywords)
+
     alias_method :new, :new_with_mock_time
   end
 end


### PR DESCRIPTION
## Problem
As of https://github.com/ruby/ruby/pull/4010, `Time.new` now accepts an optional keyword argument.

This means the monkey patch here will break in newer Ruby versions, because Ruby now requires keyword arguments be handled separately from other arguments.

## Solution
Check if `ruby2_keywords` is defined (Ruby 2.7+), and use it if it is, which will force the previous behavior.