### PR TITLE
Update CI.yml to add a weekly schedule

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - master
   pull_request:
+  schedule:
+    - cron: '0 1 * * SUN'
 
 jobs:
   build:


### PR DESCRIPTION
Add a weekly schedule to run the github CI action each Sunday, this will help detect any breakage from used gems/ruby/ci in the case nothing changes in this gem for some time