### PR TITLE
Add bin/console

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,4 +10,4 @@ RUN bundle -j 4
 
 COPY . .
 
-CMD ['bundle', 'console']
+CMD ["bin/console"]

--- a/bin/console
+++ b/bin/console
@@ -1,0 +1,15 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "bundler/setup"
+require "timecop"
+
+# You can add fixtures and/or initialization code here to make experimenting
+# with your gem easier. You can also use a different console, if you like.
+
+# (If you use this, don't forget to add pry to your Gemfile!)
+# require "pry"
+# Pry.start
+
+require "irb"
+IRB.start(__FILE__)


### PR DESCRIPTION
## what
Add bin/console. #298

## why
bundle console is Deprecated.
```bash
$ bundle console
[DEPRECATED] bundle console will be replaced by `bin/console` generated by `bundle gem <name>`
```

## check
```bash
$ bin/console
irb(main):001:0>
```