### PR TITLE
Avoid Kernel#send()

### DIFF
--- a/lib/timecop/timecop.rb
+++ b/lib/timecop/timecop.rb
@@ -13,6 +13,8 @@ class Timecop
   include Singleton
 
   class << self
+    private :instance
+
     # Allows you to run a block of code and "fake" a time throughout the execution of that block.
     # This is particularly useful for writing test methods where the passage of time is critical to the business
     # logic being tested.  For example:
@@ -74,11 +76,11 @@ class Timecop
     end
 
     def baseline
-      instance.send(:baseline)
+      instance.baseline
     end
 
     def baseline=(baseline)
-      instance.send(:baseline=, baseline)
+      instance.baseline = baseline
     end
 
     # Reverts back to system's Time.now, Date.today and DateTime.now (if it exists) permamently when
@@ -86,21 +88,21 @@ class Timecop
     # the given block.
     def return(&block)
       if block_given?
-        instance.send(:return, &block)
+        instance.return(&block)
       else
-        instance.send(:unmock!)
+        instance.unmock!
         nil
       end
     end
     alias :unfreeze :return
 
     def return_to_baseline
-      instance.send(:return_to_baseline)
+      instance.return_to_baseline
       Time.now
     end
 
     def top_stack_item #:nodoc:
-      instance.send(:stack).last
+      instance.stack.last
     end
 
     def safe_mode=(safe)
@@ -112,26 +114,24 @@ class Timecop
     end
 
     def thread_safe=(t)
-      instance.send(:thread_safe=, t)
+      instance.thread_safe = t
     end
 
     def thread_safe
-      instance.send(:thread_safe)
+      instance.thread_safe
     end
 
     # Returns whether or not Timecop is currently frozen/travelled
     def frozen?
-      !instance.send(:stack).empty?
+      !instance.stack.empty?
     end
 
     private
     def send_travel(mock_type, *args, &block)
-      val = instance.send(:travel, mock_type, *args, &block)
+      val = instance.travel(mock_type, *args, &block)
       block_given? ? val : Time.now
     end
   end
-
-  private
 
   def baseline=(b)
     set_baseline(b)


### PR DESCRIPTION
Previously all timecop instance methods were private and we would call them from the class methods using send(). This commit achieves a similar effect (making the instance methods inaccessible to users) by making `instance` private.

Using standard method calls instead of send should be slightly faster as it reduces method lookups.