### PR TITLE
Adding tests to confirm the behaviour of travel if supplied something…

### DIFF
--- a/test/timecop_test.rb
+++ b/test/timecop_test.rb
@@ -289,8 +289,12 @@ class TestTimecop < Minitest::Test
     t = Time.local(2008, 10, 10, 10, 10, 10)
     assert_times_effectively_equal t, Timecop.scale(4, t)
   end
+  
+  def test_scaling_returns_now_if_nil_supplied
+    assert_times_effectively_equal Time.now, Timecop.scale(nil)
+  end
 
-  def test_scale_raises_when_empty_string_supplied
+  def test_scaling_raises_when_empty_string_supplied
     err = assert_raises(TypeError) do
       Timecop.scale("")
     end
@@ -401,6 +405,10 @@ class TestTimecop < Minitest::Test
     end
     assert_times_effectively_equal(time_after_travel, Time.now)
   end
+  
+  def test_travel_returns_now_if_nil_supplied
+    assert_times_effectively_equal Time.now, Timecop.travel(nil)
+  end
 
   def test_travel_time_with_block_returns_the_value_of_the_block
     t_future = Time.local(2030, 10, 10, 10, 10, 10)
@@ -441,6 +449,10 @@ class TestTimecop < Minitest::Test
         assert_equal Time.now, current_time
       end
     end
+  end
+  
+   def test_freeze_returns_now_if_nil_supplied
+    assert_times_effectively_equal Time.now, Timecop.freeze(nil)
   end
 
   def test_freeze_raises_when_empty_string_supplied

--- a/test/timecop_test.rb
+++ b/test/timecop_test.rb
@@ -290,6 +290,13 @@ class TestTimecop < Minitest::Test
     assert_times_effectively_equal t, Timecop.scale(4, t)
   end
 
+  def test_scale_raises_when_empty_string_supplied
+    err = assert_raises(TypeError) do
+      Timecop.scale("")
+    end
+    assert_match /String can't be coerced into Float/, err.message
+  end
+
   def test_freeze_with_utc_time
     each_timezone do
       t = Time.utc(2008, 10, 10, 10, 10, 10)
@@ -402,6 +409,13 @@ class TestTimecop < Minitest::Test
 
     assert_equal expected, actual
   end
+  
+  def test_travel_raises_when_empty_string_supplied
+    err = assert_raises(ArgumentError) do
+      Timecop.travel("")
+    end
+    assert_match /no time information in \"\"/, err.message
+  end
 
   def test_freeze_time_returns_now_if_no_block_given
     t_future = Time.local(2030, 10, 10, 10, 10, 10)
@@ -427,6 +441,13 @@ class TestTimecop < Minitest::Test
         assert_equal Time.now, current_time
       end
     end
+  end
+
+  def test_freeze_raises_when_empty_string_supplied
+    err = assert_raises(ArgumentError) do
+      Timecop.freeze("")
+    end
+     assert_match /no time information in \"\"/, err.message
   end
 
   def test_freeze_with_new_date


### PR DESCRIPTION
… unparseable

This is a response to this open issue: https://github.com/travisjeffery/timecop/issues/213

I couldn't see an existing test covering this exact behavior so I added one intending to verify the current behavior. In doing that I discovered that the problem behavior described in the issue appears to have already been resolved.

I have submitted this test in a PR as it may be useful to confirm this is the desired behavior. If this test doesn't seem useful or there is already a test covering this then by all means decline this PR.