### PR TITLE
Capitalization for consistency

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -21,8 +21,8 @@ A gem providing "time travel" and "time freezing" capabilities, making it dead s
   - Time instance
   - DateTime instance
   - Date instance
-  - individual arguments (year, month, day, hour, minute, second)
-  - a single integer argument that is interpreted as an offset in seconds from Time.now
+  - Individual arguments (year, month, day, hour, minute, second)
+  - A single integer argument that is interpreted as an offset in seconds from Time.now
 - Nested calls to Timecop#travel and Timecop#freeze are supported -- each block will maintain its interpretation of now.
 - Works with regular Ruby projects, and Ruby on Rails projects
 


### PR DESCRIPTION
Capitalized the start of two words for consistency throughout the readme.