### PR TITLE
Explicitly require activesupport >= 4.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ group :development do
   gem 'jeweler', '< 2.1.3'
   gem 'pry'
   gem 'mocha'
-  gem 'activesupport'
+  gem 'activesupport', '>= 4.2'
   gem 'tzinfo'
   gem 'i18n'
   gem 'minitest'


### PR DESCRIPTION
The scheduled CI with Ruby 2.3, 2.4 and 2.5 fails these days.
(e.g. https://github.com/travisjeffery/timecop/actions/runs/3120487421)

I couldn't fully figure out the root cause, but it appears to be caused by the installation of activesupport v3.1.12.
Requiring activesupport v4.2 or higher solved this problem.