### PR TITLE
Revert "Explicitly require activesupport >= 4.2"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ group :development do
   gem 'jeweler', '< 2.1.3'
   gem 'pry'
   gem 'mocha'
-  gem 'activesupport', '>= 4.2'
+  gem 'activesupport'
   gem 'tzinfo'
   gem 'i18n'
   gem 'minitest'


### PR DESCRIPTION
Reverts travisjeffery/timecop#391 This didn't end up fixing the build. We played a hunch, but ruby 2.5 build still failing.