### PR TITLE
Dealing with a corrupted cache

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -35,5 +35,6 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
+          cache-version: 1
       - run: |
           bundle exec rake


### PR DESCRIPTION
This PR attempts to fix failing CI with Ruby 2.5.
refs: #391

[ruby/setup-ruby](https://github.com/ruby/setup-ruby) provides the function to cache `bundle install`, but sometimes this cache seems to corrupt.
https://github.com/ruby/setup-ruby#dealing-with-a-corrupted-cache
> In some rare scenarios (like using gems with C extensions whose functionality depends on libraries found on the system at the time of the gem's build) it may be necessary to ignore contents of the cache and get and build all the gems anew. In order to achieve this, set the `cache-version` option to any value other than `0` (or change it to a new unique value if you have already used it before.)

The most recent logs show that psych builds are failing, which is exactly the situation.
https://github.com/travisjeffery/timecop/actions/runs/3578996103/jobs/6019716355

````
...
  Fetching psych 4.0.6
  Using pry 0.14.1
  Fetching faraday 1.10.2
  --- ERROR REPORT TEMPLATE -------------------------------------------------------
  
  ```
  ArgumentError: wrong number of arguments (given 4, expected 1)
    /home/runner/work/timecop/timecop/vendor/bundle/ruby/2.5.0/gems/psych-4.0.4/lib/psych.rb:322:in `safe_load'
    /opt/hostedtoolcache/Ruby/2.5.9/x64/lib/ruby/2.5.0/rubygems/safe_yaml.rb:31:in `safe_load'
    /opt/hostedtoolcache/Ruby/2.5.9/x64/lib/ruby/2.5.0/rubygems/package.rb:496:in `block (2 levels) in read_checksums'
...
````