### PR TITLE
remove ruby 21 and 22 from matrix

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -24,8 +24,6 @@ jobs:
           - '2.5'
           - '2.4'
           - '2.3'
-          - '2.2'
-          - '2.1'
           - jruby
           - truffleruby-head
     continue-on-error: ${{ matrix.ruby == 'head' }}


### PR DESCRIPTION
```
Installing Bundler
  Bundler 2 requires Ruby 2.3+, using Bundler 1 on Ruby <= 2.2
  /opt/hostedtoolcache/Ruby/2.2.10/x64/bin/gem install bundler -v ~> 1.0
  ERROR:  While executing gem ... (RuntimeError)
      Marshal.load reentered at marshal_load
  Took   0.33 seconds
Error: The process '/opt/hostedtoolcache/Ruby/2.2.10/x64/bin/gem' failed with exit code 1
```
Our CI builds are failing because we would need to maintain different versions of bundler for these ancient rubies. 2.2 was EOL on (31 Mar 2018)... I'm just going to stop testing our code there.  According to this https://github.com/ruby/setup-ruby/issues/496 there is no workaround.