### PR TITLE
Reduce memory by not duplicating an argument

### DIFF
--- a/lib/timecop/time_stack_item.rb
+++ b/lib/timecop/time_stack_item.rb
@@ -56,7 +56,7 @@ class Timecop
 
     def time(time_klass = Time) #:nodoc:
       if @time.respond_to?(:in_time_zone)
-        time = time_klass.at(@time.dup.localtime)
+        time = time_klass.at(@time.localtime)
       else
         time = time_klass.at(@time)
       end


### PR DESCRIPTION
I spotted this in a memory_profiler report for some of my app's specs. timecop was showing up in the list of gems with the most allocated memory.

This dup appears unnecessary. The code I can see isn't making modifications to the object, and I would expect `at` to return an new object anyways.

memory_profiler before:

    allocated memory by location
    -----------------------------------
    ...
    49_836_480  /Users/josh.nichols/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/timecop-0.9.6/lib/timecop/time_stack_item.rb:59
    ...

    allocated objects by location
    -----------------------------------
    ...
    934_434  /Users/josh.nichols/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/timecop-0.9.6/lib/timecop/time_stack_item.rb:59
    ...

memory_profiler after:

    allocated memory by location
    -----------------------------------
    ...
    26_997_696  /Users/josh.nichols/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/timecop-0.9.6/lib/timecop/time_extensions.rb:79
    ...

    allocated objects by location
    -----------------------------------
    662_346  /Users/josh.nichols/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/timecop-0.9.6/lib/timecop/time_stack_item.rb:59

This decreased memory allocated in my tests by 45%, and objects allocated by 29%.