### PR TITLE
Revert "Better: Add ruby 3.1 compatibility."

### DIFF
--- a/lib/timecop/time_extensions.rb
+++ b/lib/timecop/time_extensions.rb
@@ -10,24 +10,16 @@ class Time #:nodoc:
 
     alias_method :now_without_mock_time, :now
 
-    def now_with_mock_time(*args)
-      mock_time || now_without_mock_time(*args)
+    def now_with_mock_time
+      mock_time || now_without_mock_time
     end
 
     alias_method :now, :now_with_mock_time
 
     alias_method :new_without_mock_time, :new
 
-    def new_with_mock_time(*args, **kwargs)
-      if args.size <= 0
-        now(*args)
-      else
-        if kwargs == {}
-          new_without_mock_time(*args)
-        else
-          new_without_mock_time(*args, **kwargs)
-        end
-      end
+    def new_with_mock_time(*args)
+      args.size <= 0 ? now : new_without_mock_time(*args)
     end
 
     ruby2_keywords :new_with_mock_time if Module.private_method_defined?(:ruby2_keywords)


### PR DESCRIPTION
Reverts travisjeffery/timecop#279

This PR isn't working on ruby 3.1 build

```
/home/runner/work/timecop/timecop/lib/timecop/time_extensions.rb:7:in `mock_time': stack level too deep (SystemStackError)
```