### PR TITLE
380 week of year fix

### DIFF
--- a/lib/timecop/time_extensions.rb
+++ b/lib/timecop/time_extensions.rb
@@ -52,8 +52,7 @@ class Date #:nodoc:
       now = Time.now.to_date
       year = d[:year] || now.year
       mon = d[:mon] || now.mon
-      leftover = d[:leftover] || 0
-      if d.keys == [:year]
+      the_date = if d.keys == [:year]
         Date.new(year, 1, 1, start)
       elsif d[:mday]
         Date.new(year, mon, d[:mday], start)
@@ -68,8 +67,7 @@ class Date #:nodoc:
           Date.commercial(d[:cwyear], d[:cweek], 1, start)
         end
       elsif d[:wnum1]
-        fraction_of_a_day = Rational(leftover, 60*60*24)
-        Date.commercial(year, d[:wnum1], 1, start) + fraction_of_a_day
+        Date.commercial(year, d[:wnum1], 1, start)
       elsif d[:seconds]
         Time.at(d[:seconds]).to_date
       else

--- a/lib/timecop/time_extensions.rb
+++ b/lib/timecop/time_extensions.rb
@@ -52,6 +52,7 @@ class Date #:nodoc:
       now = Time.now.to_date
       year = d[:year] || now.year
       mon = d[:mon] || now.mon
+      leftover = d[:leftover] || 0
       if d.keys == [:year]
         Date.new(year, 1, 1, start)
       elsif d[:mday]
@@ -66,6 +67,9 @@ class Date #:nodoc:
         else
           Date.commercial(d[:cwyear], d[:cweek], 1, start)
         end
+      elsif d[:wnum1]
+        fraction_of_a_day = Rational(leftover, 60*60*24)
+        Date.commercial(year, d[:wnum1], 1, start) + fraction_of_a_day
       elsif d[:seconds]
         Time.at(d[:seconds]).to_date
       else

--- a/lib/timecop/time_extensions.rb
+++ b/lib/timecop/time_extensions.rb
@@ -52,7 +52,7 @@ class Date #:nodoc:
       now = Time.now.to_date
       year = d[:year] || now.year
       mon = d[:mon] || now.mon
-      the_date = if d.keys == [:year]
+      if d.keys == [:year]
         Date.new(year, 1, 1, start)
       elsif d[:mday]
         Date.new(year, mon, d[:mday], start)

--- a/lib/timecop/time_extensions.rb
+++ b/lib/timecop/time_extensions.rb
@@ -50,24 +50,22 @@ class Date #:nodoc:
 
       d = Date._strptime(str, fmt)
       now = Time.now.to_date
-      year = d[:year] || now.year
+      year = d[:year] || d[:cwyear] || now.year
       mon = d[:mon] || now.mon
       if d.keys == [:year]
         Date.new(year, 1, 1, start)
       elsif d[:mday]
         Date.new(year, mon, d[:mday], start)
-      elsif d[:wday]
-        Date.new(year, mon, now.mday, start) + (d[:wday] - now.wday)
       elsif d[:yday]
         Date.new(year, 1, 1, start).next_day(d[:yday] - 1)
-      elsif d[:cwyear] && d[:cweek]
-        if d[:cwday]
-          Date.commercial(d[:cwyear], d[:cweek], d[:cwday], start)
-        else
-          Date.commercial(d[:cwyear], d[:cweek], 1, start)
-        end
-      elsif d[:wnum1]
-        Date.commercial(year, d[:wnum1], 1, start)
+      elsif d[:cwyear] || d[:cweek] || d[:wnum1] || d[:wday] || d[:cwday]
+        day_of_week_from_monday = if d[:wday]
+                                    (d[:wday] + 6)%7 + 1
+                                  else
+                                    d[:cwday] || 1
+                                  end
+        week = d[:cweek] || d[:wnum1] || now.strftime('%W').to_i
+        Date.commercial(year, week, day_of_week_from_monday, start)
       elsif d[:seconds]
         Time.at(d[:seconds]).to_date
       else

--- a/test/date_strptime_scenarios.rb
+++ b/test/date_strptime_scenarios.rb
@@ -35,6 +35,14 @@ module DateStrptimeScenarios
     assert_equal Date.strptime('1984-W09-1', '%G-W%V-%u'), Date.new(1984, 2, 27)
   end
 
+  def test_date_strptime_with_week_number_of_year
+    assert_equal Date.strptime('201810', '%Y%W'), Date.new(2018, 3, 5)
+  end
+
+  def test_date_strptime_with_just_week_number_of_year
+    assert_equal Date.strptime('14', '%W'), Date.new(1984, 4, 02)
+  end
+
   def test_date_strptime_with_seconds_since_epoch
     assert_equal Date.strptime('446731200', '%s'), Date.new(1984, 2, 27)
   end

--- a/test/date_strptime_scenarios.rb
+++ b/test/date_strptime_scenarios.rb
@@ -32,8 +32,23 @@ module DateStrptimeScenarios
   end
 
   def test_date_strptime_with_commercial_week_date_and_day_of_week_from_sunday
+    #2/27/1984 is a monday. wed the 29th is the last day of march.
+
+    #1984-09 is 9th commercial week of 1984 starting on monday 2/27
+    #specifying day of week = 0 with non-commercial day of week means
+    #we jump to sunday, so 6 days after monday 2/27 which is 3/4
     assert_equal Date.strptime('1984-09-0', '%G-%V-%w'), Date.new(1984, 3, 04)
+    assert_equal Date.strptime('1984-09-1', '%G-%V-%w'), Date.new(1984, 2, 27)
+    assert_equal Date.strptime('1984-09-2', '%G-%V-%w'), Date.new(1984, 2, 28)
+    assert_equal Date.strptime('1984-09-3', '%G-%V-%w'), Date.new(1984, 2, 29)
+    assert_equal Date.strptime('1984-09-6', '%G-%V-%w'), Date.new(1984, 3, 03)
+
+    #1984-09 is 9th commercial week of 1984 starting on a monday
+    #specifying day of week = 1 with commercial day of week means stay at the 27th
     assert_equal Date.strptime('1984-09-1', '%G-%V-%u'), Date.new(1984, 2, 27)
+    assert_equal Date.strptime('1984-09-2', '%G-%V-%u'), Date.new(1984, 2, 28)
+    assert_equal Date.strptime('1984-09-3', '%G-%V-%u'), Date.new(1984, 2, 29)
+    assert_equal Date.strptime('1984-09-7', '%G-%V-%u'), Date.new(1984, 3, 04)
   end
 
   def test_date_strptime_with_iso_8601_week_date

--- a/test/date_strptime_scenarios.rb
+++ b/test/date_strptime_scenarios.rb
@@ -36,7 +36,7 @@ module DateStrptimeScenarios
     assert_equal Date.strptime('1984-W09-1', '%G-W%V-%u'), Date.new(1984, 2, 27)
   end
 
-  def test_date_strptime_with_week_number_of_year
+  def test_date_strptime_with_year_and_week_number_of_year
     assert_equal Date.strptime('201810', '%Y%W'), Date.new(2018, 3, 5)
   end
 

--- a/test/date_strptime_scenarios.rb
+++ b/test/date_strptime_scenarios.rb
@@ -114,24 +114,21 @@ module DateStrptimeScenarios
       [
         '%Y %m %d',
         '%C %y %m %d',
-
         '%Y %j',
         '%C %y %j',
-
+        '%G %V %w',
+        '%G %V %u',
+        '%C %g %V %w',
+        '%C %g %V %u',
+        '%Y %W %w',
+        '%Y %W %u',
+        '%C %y %W %w',
+        '%C %y %W %u',
         #TODO Support these formats
-        # '%G %V %w',
-        # '%G %V %u',
-        # '%C %g %V %w',
-        # '%C %g %V %u',
-
         # '%Y %U %w',
         # '%Y %U %u',
-        # '%Y %W %w',
-        # '%Y %W %u',
         # '%C %y %U %w',
         # '%C %y %U %u',
-        # '%C %y %W %w',
-        # '%C %y %W %u',
       ].each do |fmt|
         s = d.strftime(fmt)
         d2 = Date.strptime(s, fmt)

--- a/test/date_strptime_scenarios.rb
+++ b/test/date_strptime_scenarios.rb
@@ -25,7 +25,6 @@ module DateStrptimeScenarios
   def test_date_strptime_with_day_of_week
     assert_equal Date.strptime('Thursday', '%A'), Date.new(1984, 3, 1)
     assert_equal Date.strptime('Monday', '%A'), Date.new(1984, 2, 27)
-    assert_equal Date.strptime('Monday', '%A'), Date.new(1984, 2, 27)
   end
 
   def test_date_strptime_with_commercial_week_date

--- a/test/date_strptime_scenarios.rb
+++ b/test/date_strptime_scenarios.rb
@@ -31,6 +31,11 @@ module DateStrptimeScenarios
     assert_equal Date.strptime('1984-09', '%G-%V'), Date.new(1984, 2, 27)
   end
 
+  def test_date_strptime_with_commercial_week_date_and_day_of_week_from_sunday
+    assert_equal Date.strptime('1984-09-0', '%G-%V-%w'), Date.new(1984, 3, 04)
+    assert_equal Date.strptime('1984-09-1', '%G-%V-%u'), Date.new(1984, 2, 27)
+  end
+
   def test_date_strptime_with_iso_8601_week_date
     assert_equal Date.strptime('1984-W09-1', '%G-W%V-%u'), Date.new(1984, 2, 27)
   end
@@ -39,8 +44,16 @@ module DateStrptimeScenarios
     assert_equal Date.strptime('201810', '%Y%W'), Date.new(2018, 3, 5)
   end
 
+  def test_date_strptime_with_year_and_week_number_of_year_and_day_of_week_from_monday
+    assert_equal Date.strptime('2018107', '%Y%W%u'), Date.new(2018, 3, 11)
+  end
+
   def test_date_strptime_with_just_week_number_of_year
     assert_equal Date.strptime('14', '%W'), Date.new(1984, 4, 02)
+  end
+
+  def test_date_strptime_week_of_year_and_day_of_week_from_sunday
+    assert_equal Date.strptime('140', '%W%w'), Date.new(1984, 4, 8)
   end
 
   def test_date_strptime_with_seconds_since_epoch

--- a/test/date_strptime_scenarios.rb
+++ b/test/date_strptime_scenarios.rb
@@ -25,6 +25,7 @@ module DateStrptimeScenarios
   def test_date_strptime_with_day_of_week
     assert_equal Date.strptime('Thursday', '%A'), Date.new(1984, 3, 1)
     assert_equal Date.strptime('Monday', '%A'), Date.new(1984, 2, 27)
+    assert_equal Date.strptime('Monday', '%A'), Date.new(1984, 2, 27)
   end
 
   def test_date_strptime_with_commercial_week_date


### PR DESCRIPTION
While I was trying to handle the non-commercial week of the year (which is where the week starts on a sunday). I realized there were scenarios where you could mix commercial date stuff with non-commercial date stuff so had to come up with a consolidated way to handle that. I came up with always converting day of week to a monday start based day of week.

This made all our other scenarios pass without so much conditional logic and seems to handle this mix/match stuff as well.