### PR TITLE
fix week based dates

### DIFF
--- a/lib/timecop/time_extensions.rb
+++ b/lib/timecop/time_extensions.rb
@@ -58,14 +58,21 @@ class Date #:nodoc:
         Date.new(year, mon, d[:mday], start)
       elsif d[:yday]
         Date.new(year, 1, 1, start).next_day(d[:yday] - 1)
-      elsif d[:cwyear] || d[:cweek] || d[:wnum1] || d[:wday] || d[:cwday]
-        day_of_week_from_monday = if d[:wday]
-                                    (d[:wday] + 6)%7 + 1
-                                  else
-                                    d[:cwday] || 1
-                                  end
-        week = d[:cweek] || d[:wnum1] || now.strftime('%W').to_i
-        Date.commercial(year, week, day_of_week_from_monday, start)
+      elsif d[:cwyear] || d[:cweek] || d[:wnum0] || d[:wnum1] || d[:wday] || d[:cwday]
+        week = d[:cweek] || d[:wnum1] || d[:wnum0] || now.strftime('%W').to_i
+        if d[:wnum0] #Week of year where week starts on sunday
+          if d[:cwday] #monday based day of week
+            Date.strptime_without_mock_date("#{year} #{week} #{d[:cwday]}", '%Y %U %u', start)
+          else
+            Date.strptime_without_mock_date("#{year} #{week} #{d[:wday] || 0}", '%Y %U %w', start)
+          end
+        else #Week of year where week starts on monday
+          if d[:wday] #sunday based day of week
+            Date.strptime_without_mock_date("#{year} #{week} #{d[:wday]}", '%Y %W %w', start)
+          else
+            Date.strptime_without_mock_date("#{year} #{week} #{d[:cwday] || 1}", '%Y %W %u', start)
+          end
+        end
       elsif d[:seconds]
         Time.at(d[:seconds]).to_date
       else

--- a/test/date_strptime_scenarios.rb
+++ b/test/date_strptime_scenarios.rb
@@ -51,6 +51,10 @@ module DateStrptimeScenarios
     assert_equal Date.strptime('1984-09-7', '%G-%V-%u'), Date.new(1984, 3, 04)
   end
 
+  def test_date_strptime_week_number_of_year_day_of_week_sunday_start
+    assert_equal Date.strptime('1984 09 0', '%Y %U %w'), Date.new(1984, 2, 26)
+  end
+
   def test_date_strptime_with_iso_8601_week_date
     assert_equal Date.strptime('1984-W09-1', '%G-W%V-%u'), Date.new(1984, 2, 27)
   end
@@ -124,11 +128,10 @@ module DateStrptimeScenarios
         '%Y %W %u',
         '%C %y %W %w',
         '%C %y %W %u',
-        #TODO Support these formats
-        # '%Y %U %w',
-        # '%Y %U %u',
-        # '%C %y %U %w',
-        # '%C %y %U %u',
+        '%Y %U %w',
+        '%Y %U %u',
+        '%C %y %U %w',
+        '%C %y %U %u',
       ].each do |fmt|
         s = d.strftime(fmt)
         d2 = Date.strptime(s, fmt)

--- a/test/date_strptime_scenarios.rb
+++ b/test/date_strptime_scenarios.rb
@@ -18,6 +18,11 @@ module DateStrptimeScenarios
     assert_equal Date.strptime("153", '%j'), Date.new(1984, 6, 1)
   end
 
+  def test_date_strptime_day_of_year_with_year
+    assert_equal Date.strptime("1999 153", '%Y %j'), Date.new(1999, 6, 2)
+  end
+
+
   def test_date_strptime_without_specifying_format
     assert_equal Date.strptime('1999-04-14'), Date.new(1999, 4, 14)
   end


### PR DESCRIPTION
While trying to get the rest of the TODO date formats to work I found a bug with the previous week based date handling. If we were given a date like Date.strptime('2006 23 0', '%Y %U %w') our code would come up with 2006/6/11. But it is actually 2006/6/4

The problem is that we were trying to use Date.commercial for everything but some weeks a given sunday based date isn't even in the same week as the monday based weeks that Date.commercial uses. See below. 6/4 is in the 22nd commercial week but 23rd non-commercial

```
2006 - 23rd week of the year...

Monday start    -   Sunday start
[Mon 6/5] 23 1  -  [Sun 6/4] 23 0
[Tu  6/6] 23 2  -  [Mon 6/5] 23 1
[We  6/7] 23 3  -  [Tu  6/6] 23 2
[Th  6/8] 23 4  -  [We  6/7] 23 3
[Fr  6/9] 23 5  -  [Th  6/8] 23 4
[Sa 6/10] 23 6  -  [Fr  6/9] 23 5
[Su 6/11] 23 7  -  [Sa 6/10] 23 6
```

I'm proposing this alternative implementation where we delegate to the unmocked strptime but pass it a fully qualified date string that is populated from our mocked time where appropriate. This is now working for all the TODO date formats. I'm not crazy about this implementation since it feels icky to have this one scenario where we are using strptime to compute the new date. Without having something like Date.non_commercial that takes the sunday based weeks I'm not sure what else to do.