### PR TITLE
Add methods to allow Timecop instance checking if in a travelled or scaled state

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,5 +1,10 @@
 # History
 
+## Unreleased
+
+- Add `travelled?` and `scaled?` methods to allow checking if Timecop is in their respective states ([#414](https://github.com/travisjeffery/timecop/pull/414))
+
+
 ## v0.9.8
 
 - Revert Reduce memory usage ([#404](https://github.com/travisjeffery/timecop/pull/404))

--- a/lib/timecop/timecop.rb
+++ b/lib/timecop/timecop.rb
@@ -126,6 +126,16 @@ class Timecop
       !instance.stack.empty? && instance.stack.last.mock_type == :freeze
     end
 
+    # Returns whether or not Timecop is currently travelled
+    def travelled?
+      !instance.stack.empty? && instance.stack.last.mock_type == :travel
+    end
+
+    # Returns whether or not Timecop is currently scaled
+    def scaled?
+      !instance.stack.empty? && instance.stack.last.mock_type == :scale
+    end
+
     private
     def send_travel(mock_type, *args, &block)
       val = instance.travel(mock_type, *args, &block)

--- a/test/timecop_test.rb
+++ b/test/timecop_test.rb
@@ -605,6 +605,39 @@ class TestTimecop < Minitest::Test
     end
   end
 
+  def test_not_travelled_and_not_scaled_inside_freeze
+    Timecop.freeze do
+      assert !Timecop.travelled?
+      assert !Timecop.scaled?
+    end
+  end
+
+  def test_travelled_and_not_scaled_inside_travel
+    Timecop.travel(3) do
+      assert Timecop.travelled?
+      assert !Timecop.scaled?
+    end
+  end
+
+  def test_scaled_and_not_travelled_inside_scale
+    Timecop.scale(4) do
+      assert Timecop.scaled?
+      assert !Timecop.travelled?
+    end
+  end
+
+  def test_not_scaled_after_scale
+    Timecop.scale(5)
+    Timecop.return
+    assert !Timecop.scaled?
+  end
+
+  def test_not_travelled_after_travel
+    Timecop.travel(6)
+    Timecop.return
+    assert !Timecop.travelled?
+  end
+
   def test_not_frozen_inside_first_freeze_then_scale
     Timecop.freeze do
       assert Timecop.frozen?


### PR DESCRIPTION
In a recent Timecop release (0.9.7, commit [c57a1fc](https://github.com/travisjeffery/timecop/commit/c57a1fce6468f594738674376dbcb29fe9dc1627)), a fix was made to the boolean method`#frozen?` which previously returned `true` if Timecop was active at that instance in time (frozen, scaled or travelled). This method was changed so that only returned `true` if Timecop was in a frozen state. Once this change was made it was no longer possible to check if Timecop was in a `scaled` or `travelled` state.

As a result of this change, our automated test suite, which relied on the previous behaviour of `frozen?` failed (we used it to check if Timecop present in any way in a database helper, and it affected how our automated factory objects were being created where dates are involved). We discovered this after investigating a dependabot automated gem update failure.

This PR exposes two additional methods `scaled?` and `travelled?` to allow a consumer to check for these states. I did consider an alternative method `active?` which would have been the previous `frozen?` behaviour, but decided to be explicit in these new methods.

I've added in some additional tests to cover what I think are most of the examples.

(Note: will update changelog if this PR is likely to get merged)

Thank you