### PR TITLE
ActiveSupport Date.current differs from Date.today when Time.zone is set

### DIFF
--- a/test/active_support_date_current_test.rb
+++ b/test/active_support_date_current_test.rb
@@ -5,23 +5,11 @@ require 'active_support/core_ext/date/calculations'
 
 class TestActiveSupportDateCurrent < Minitest::Test
   def test_date_current_same_as_date_today_with_time_zone
-    puts "Before Timecop.freeze"
-    puts "ENV['TZ']: #{ENV['TZ']}"
-    puts "Time.zone: #{Time.zone}"
-    puts
-
-    old_zone = Time.zone
-    begin
+    each_timezone do
       Time.zone = "UTC"
       Timecop.freeze("2024-03-15") do
-        puts "Within Timecop.freeze"
-        puts "ENV['TZ']: #{ENV['TZ']}"
-        puts "Time.zone: #{Time.zone}"
-
         assert_equal Date.current, Date.today
       end
-    ensure
-      Time.zone = old_zone
     end
   end
 end


### PR DESCRIPTION
Edit: https://github.com/travisjeffery/timecop/pull/416#issuecomment-2289702440 for diagnosis

Original description:

I suspect https://github.com/travisjeffery/timecop/blob/e134761e942c612f8199f2d83793995653f810cb/lib/timecop/time_stack_item.rb#L59 calling localtime to be causing this issue. My system localtime is -7, so this cast is changing the date to the previous day. Diff is a failing test.