### PR TITLE
Add `Process.clock_gettime` support

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -5,7 +5,7 @@
 
 ## DESCRIPTION
 
-A gem providing "time travel" and "time freezing" capabilities, making it dead simple to test time-dependent code.  It provides a unified method to mock `Time.now`, `Date.today`, and `DateTime.now` in a single call.
+A gem providing "time travel" and "time freezing" capabilities, making it dead simple to test time-dependent code. It provides a unified method to mock `Time.now`, `Date.today`, `DateTime.now`, and `Process.clock_gettime` in a single call.
 
 ## INSTALL
 

--- a/lib/timecop/time_extensions.rb
+++ b/lib/timecop/time_extensions.rb
@@ -158,3 +158,59 @@ class DateTime #:nodoc:
     end
   end
 end
+
+if RUBY_VERSION >= '2.1.0'
+  module Process #:nodoc:
+    class << self
+      alias_method :clock_gettime_without_mock, :clock_gettime
+
+      def clock_gettime_mock_time(clock_id, unit = :float_second)
+        mock_time = case clock_id
+                    when Process::CLOCK_MONOTONIC
+                      mock_time_monotonic
+                    when Process::CLOCK_REALTIME
+                      mock_time_realtime
+                    end
+
+        return clock_gettime_without_mock(clock_id, unit) unless mock_time
+
+        divisor = case unit
+                  when :float_second
+                    1_000_000_000.0
+                  when :second
+                    1_000_000_000
+                  when :float_millisecond
+                    1_000_000.0
+                  when :millisecond
+                    1_000_000
+                  when :float_microsecond
+                    1000.0
+                  when :microsecond
+                    1000
+                  when :nanosecond
+                    1
+                  end
+
+        (mock_time / divisor)
+      end
+
+      alias_method :clock_gettime, :clock_gettime_mock_time
+
+      private
+
+      def mock_time_monotonic
+        mocked_time_stack_item = Timecop.top_stack_item
+        mocked_time_stack_item.nil? ? nil : mocked_time_stack_item.monotonic
+      end
+
+      def mock_time_realtime
+        mocked_time_stack_item = Timecop.top_stack_item
+
+        return nil if mocked_time_stack_item.nil?
+
+        t = mocked_time_stack_item.time
+        t.to_i * 1_000_000_000 + t.nsec
+      end
+    end
+  end
+end

--- a/lib/timecop/time_stack_item.rb
+++ b/lib/timecop/time_stack_item.rb
@@ -9,6 +9,7 @@ class Timecop
       @travel_offset  = @scaling_factor = nil
       @scaling_factor = args.shift if mock_type == :scale
       @mock_type      = mock_type
+      @monotonic      = current_monotonic if RUBY_VERSION >= '2.1.0'
       @time           = parse_time(*args)
       @time_was       = Time.now_without_mock_time
       @travel_offset  = compute_travel_offset
@@ -52,6 +53,22 @@ class Timecop
 
     def scaling_factor
       @scaling_factor
+    end
+
+    if RUBY_VERSION >= '2.1.0'
+      def monotonic
+        if travel_offset.nil?
+          @monotonic
+        elsif scaling_factor.nil?
+          current_monotonic + travel_offset * (10 ** 9)
+        else
+          (@monotonic + (current_monotonic - @monotonic) * scaling_factor).to_i
+        end
+      end
+
+      def current_monotonic
+        Process.clock_gettime_without_mock(Process::CLOCK_MONOTONIC, :nanosecond)
+      end
     end
 
     def time(time_klass = Time) #:nodoc:
@@ -106,6 +123,7 @@ class Timecop
       elsif Object.const_defined?(:Date) && arg.is_a?(Date)
         time_klass.local(arg.year, arg.month, arg.day, 0, 0, 0)
       elsif args.empty? && (arg.kind_of?(Integer) || arg.kind_of?(Float))
+        @monotonic += arg * 1_000_000_000 if RUBY_VERSION >= '2.1.0'
         time_klass.now + arg
       elsif arg.nil?
         time_klass.now

--- a/lib/timecop/time_stack_item.rb
+++ b/lib/timecop/time_stack_item.rb
@@ -9,7 +9,7 @@ class Timecop
       @travel_offset  = @scaling_factor = nil
       @scaling_factor = args.shift if mock_type == :scale
       @mock_type      = mock_type
-      @monotonic      = current_monotonic if RUBY_VERSION >= '2.1.0'
+      @monotonic      = current_monotonic_with_mock if RUBY_VERSION >= '2.1.0'
       @time           = parse_time(*args)
       @time_was       = Time.now_without_mock_time
       @travel_offset  = compute_travel_offset
@@ -68,6 +68,10 @@ class Timecop
 
       def current_monotonic
         Process.clock_gettime_without_mock(Process::CLOCK_MONOTONIC, :nanosecond)
+      end
+
+      def current_monotonic_with_mock
+        Process.clock_gettime_mock_time(Process::CLOCK_MONOTONIC, :nanosecond)
       end
     end
 

--- a/lib/timecop/timecop.rb
+++ b/lib/timecop/timecop.rb
@@ -38,6 +38,12 @@ class Timecop
     # previous values after the block has finished executing.  This allows us to nest multiple
     # calls to Timecop.travel and have each block maintain it's concept of "now."
     #
+    # The Process.clock_gettime call mocks both CLOCK::MONOTIC and CLOCK::REALTIME
+    #
+    # CLOCK::MONOTONIC works slightly differently than other clocks. This clock cannot move to a
+    # particular date/time. So the only option that changes this clock is #4 which will move the
+    # clock the requested offset. Otherwise the clock is frozen to the current tick.
+    #
     # * Note: Timecop.freeze will actually freeze time.  This can cause unanticipated problems if
     #   benchmark or other timing calls are executed, which implicitly expect Time to actually move
     #   forward.

--- a/test/timecop_test.rb
+++ b/test/timecop_test.rb
@@ -2,7 +2,7 @@ require_relative "test_helper"
 require 'timecop'
 
 class TestTimecop < Minitest::Test
-  TIME_EPSILON = 0.001
+  TIME_EPSILON = 0.001 # seconds - represents enough time for Process.clock_gettime to have advanced if not frozen
 
   def teardown
     Timecop.return
@@ -707,7 +707,7 @@ class TestTimecop < Minitest::Test
       Timecop.freeze do
         parent = monotonic
 
-        sleep(0.01)
+        sleep(TIME_EPSILON)
 
         delta = 0.5
         Timecop.freeze(delta) do

--- a/test/timecop_test.rb
+++ b/test/timecop_test.rb
@@ -284,7 +284,7 @@ class TestTimecop < Minitest::Test
     t = Time.local(2008, 10, 10, 10, 10, 10)
     assert_times_effectively_equal t, Timecop.scale(4, t)
   end
-
+  
   def test_scaling_returns_now_if_nil_supplied
     assert_times_effectively_equal Time.now, Timecop.scale(nil)
   end
@@ -421,7 +421,7 @@ class TestTimecop < Minitest::Test
     end
     assert_times_effectively_equal(time_after_travel, Time.now)
   end
-
+  
   def test_travel_returns_now_if_nil_supplied
     assert_times_effectively_equal Time.now, Timecop.travel(nil)
   end
@@ -433,7 +433,7 @@ class TestTimecop < Minitest::Test
 
     assert_equal expected, actual
   end
-
+  
   def test_travel_raises_when_empty_string_supplied
     err = assert_raises(ArgumentError) do
       Timecop.travel("")
@@ -466,7 +466,7 @@ class TestTimecop < Minitest::Test
       end
     end
   end
-
+  
    def test_freeze_returns_now_if_nil_supplied
     assert_times_effectively_equal Time.now, Timecop.freeze(nil)
   end

--- a/test/timecop_test.rb
+++ b/test/timecop_test.rb
@@ -705,11 +705,12 @@ class TestTimecop < Minitest::Test
       Timecop.freeze do
         parent = monotonic
 
-        sleep(0.1)
+        sleep(0.01)
 
-        Timecop.freeze(0.5) do
+        delta = 0.5
+        Timecop.freeze(delta) do
           child = monotonic
-          assert_times_effectively_equal(child, parent + 0.5, 0.001, "Nested freeze not working for monotonic time")
+          assert_equal(child, parent + delta, "Nested freeze not working for monotonic time")
         end
       end
     end
@@ -718,14 +719,12 @@ class TestTimecop < Minitest::Test
       current = monotonic
       Timecop.travel do
         refute_same monotonic, monotonic, "CLOCK_MONOTONIC is frozen"
-        sleep 0.5
-        assert monotonic > current, "CLOCK_MONOTONIC is not moving forward"
+        assert_operator(monotonic, :>, current, "CLOCK_MONOTONIC is not moving forward")
       end
 
       Timecop.travel(-0.5) do
         refute_same monotonic, monotonic, "CLOCK_MONOTONIC is frozen"
-        sleep 0.5
-        assert monotonic > current, "CLOCK_MONOTONIC is not traveling properly"
+        assert_operator(monotonic, :<, current, "CLOCK_MONOTONIC is not traveling properly")
       end
     end
 

--- a/test/timecop_test.rb
+++ b/test/timecop_test.rb
@@ -697,7 +697,7 @@ class TestTimecop < Minitest::Test
 
       initial_time = monotonic
       Timecop.freeze(-0.5) do
-        assert monotonic < initial_time, "CLOCK_MONOTONIC is not traveling back in time"
+        assert_operator(monotonic, :<, initial_time, "CLOCK_MONOTONIC is not traveling back in time")
       end
     end
 
@@ -746,7 +746,7 @@ class TestTimecop < Minitest::Test
 
       initial_time = realtime
       Timecop.freeze(-20) do
-        assert realtime < initial_time, "CLOCK_REALTIME is not traveling back in time"
+        assert_operator(realtime, :<, initial_time, "CLOCK_REALTIME is not traveling back in time")
       end
     end
 
@@ -754,7 +754,7 @@ class TestTimecop < Minitest::Test
       initial_time = realtime
       Timecop.travel do
         refute_equal realtime, realtime, "CLOCK_REALTIME is frozen"
-        assert realtime > initial_time, "CLOCK_REALTIME is not moving forward"
+        assert_operator(realtime, :>, initial_time, "CLOCK_REALTIME is not moving forward")
       end
 
       Timecop.travel(Time.now - 0.1) do
@@ -771,7 +771,7 @@ class TestTimecop < Minitest::Test
       Timecop.scale(scale) do
         initial_time = realtime
         sleep(sleep_length)
-        assert initial_time + scale * sleep_length < realtime, "CLOCK_REALTIME is not scaling"
+        assert_operator(initial_time + scale * sleep_length, :<, realtime, "CLOCK_REALTIME is not scaling")
       end
     end
   end

--- a/test/timecop_test.rb
+++ b/test/timecop_test.rb
@@ -759,10 +759,11 @@ class TestTimecop < Minitest::Test
         assert_operator(realtime, :>, initial_time, "CLOCK_REALTIME is not moving forward")
       end
 
-      Timecop.travel(Time.now - 0.1) do
+      delta = 0.1
+      Timecop.travel(Time.now - delta) do
         refute_equal consecutive_realtime, "CLOCK_REALTIME is frozen"
         assert_operator(realtime, :<, initial_time, "CLOCK_REALTIME is not traveling properly")
-        sleep 0.1
+        sleep(delta)
         assert_operator(realtime, :>, initial_time, "CLOCK_REALTIME is not traveling properly")
       end
     end

--- a/test/timecop_test.rb
+++ b/test/timecop_test.rb
@@ -701,6 +701,19 @@ class TestTimecop < Minitest::Test
       end
     end
 
+    def test_process_clock_gettime_monotonic_nested
+      Timecop.freeze do
+        parent = monotonic
+
+        sleep(0.1)
+
+        Timecop.freeze(0.5) do
+          child = monotonic
+          assert_times_effectively_equal(child, parent + 0.5, 0.001, "Nested freeze not working for monotonic time")
+        end
+      end
+    end
+
     def test_process_clock_gettime_monotonic_travel
       current = monotonic
       Timecop.travel do

--- a/test/timecop_test.rb
+++ b/test/timecop_test.rb
@@ -695,9 +695,9 @@ class TestTimecop < Minitest::Test
         assert_same monotonic, monotonic, "CLOCK_MONOTONIC is not frozen"
       end
 
-      current = monotonic
+      initial_time = monotonic
       Timecop.freeze(-0.5) do
-        assert monotonic < current, "CLOCK_MONOTONIC is not traveling back in time"
+        assert monotonic < initial_time, "CLOCK_MONOTONIC is not traveling back in time"
       end
     end
 
@@ -716,15 +716,15 @@ class TestTimecop < Minitest::Test
     end
 
     def test_process_clock_gettime_monotonic_travel
-      current = monotonic
+      initial_time = monotonic
       Timecop.travel do
         refute_same monotonic, monotonic, "CLOCK_MONOTONIC is frozen"
-        assert_operator(monotonic, :>, current, "CLOCK_MONOTONIC is not moving forward")
+        assert_operator(monotonic, :>, initial_time, "CLOCK_MONOTONIC is not moving forward")
       end
 
       Timecop.travel(-0.5) do
         refute_same monotonic, monotonic, "CLOCK_MONOTONIC is frozen"
-        assert_operator(monotonic, :<, current, "CLOCK_MONOTONIC is not traveling properly")
+        assert_operator(monotonic, :<, initial_time, "CLOCK_MONOTONIC is not traveling properly")
       end
     end
 
@@ -732,9 +732,9 @@ class TestTimecop < Minitest::Test
       scale = 4
       sleep_length = 0.25
       Timecop.scale(scale) do
-        current = monotonic
+        initial_time = monotonic
         sleep(sleep_length)
-        expected_time = current + (scale * sleep_length)
+        expected_time = initial_time + (scale * sleep_length)
         assert_times_effectively_equal expected_time, monotonic, 0.1, "CLOCK_MONOTONIC is not scaling"
       end
     end
@@ -744,24 +744,24 @@ class TestTimecop < Minitest::Test
         assert_same realtime, realtime, "CLOCK_REALTIME is not frozen"
       end
 
-      current = realtime
+      initial_time = realtime
       Timecop.freeze(-20) do
-        assert realtime < current, "CLOCK_REALTIME is not traveling back in time"
+        assert realtime < initial_time, "CLOCK_REALTIME is not traveling back in time"
       end
     end
 
     def test_process_clock_gettime_realtime_travel
-      current = realtime
+      initial_time = realtime
       Timecop.travel do
         refute_equal realtime, realtime, "CLOCK_REALTIME is frozen"
-        assert realtime > current, "CLOCK_REALTIME is not moving forward"
+        assert realtime > initial_time, "CLOCK_REALTIME is not moving forward"
       end
 
       Timecop.travel(Time.now - 0.1) do
         refute_equal realtime, realtime, "CLOCK_REALTIME is frozen"
-        assert_operator(realtime, :<, current, "CLOCK_REALTIME is not traveling properly")
+        assert_operator(realtime, :<, initial_time, "CLOCK_REALTIME is not traveling properly")
         sleep 0.1
-        assert_operator(realtime, :>, current, "CLOCK_REALTIME is not traveling properly")
+        assert_operator(realtime, :>, initial_time, "CLOCK_REALTIME is not traveling properly")
       end
     end
 
@@ -769,9 +769,9 @@ class TestTimecop < Minitest::Test
       scale = 4
       sleep_length = 0.25
       Timecop.scale(scale) do
-        current = realtime
+        initial_time = realtime
         sleep(sleep_length)
-        assert current + scale * sleep_length < realtime, "CLOCK_REALTIME is not scaling"
+        assert initial_time + scale * sleep_length < realtime, "CLOCK_REALTIME is not scaling"
       end
     end
   end

--- a/test/timecop_test.rb
+++ b/test/timecop_test.rb
@@ -757,11 +757,11 @@ class TestTimecop < Minitest::Test
         assert realtime > current, "CLOCK_REALTIME is not moving forward"
       end
 
-      Timecop.travel(Time.now - 0.5) do
+      Timecop.travel(Time.now - 0.1) do
         refute_equal realtime, realtime, "CLOCK_REALTIME is frozen"
-        assert realtime < current, "CLOCK_REALTIME is not traveling properly"
-        sleep 0.5
-        assert realtime > current, "CLOCK_REALTIME is not traveling properly"
+        assert_operator(realtime, :<, current, "CLOCK_REALTIME is not traveling properly")
+        sleep 0.1
+        assert_operator(realtime, :>, current, "CLOCK_REALTIME is not traveling properly")
       end
     end
 

--- a/test/timecop_test.rb
+++ b/test/timecop_test.rb
@@ -2,8 +2,6 @@ require_relative "test_helper"
 require 'timecop'
 
 class TestTimecop < Minitest::Test
-  TIME_EPSILON = 0.001 # seconds - represents enough time for Process.clock_gettime to have advanced if not frozen
-
   def teardown
     Timecop.return
   end
@@ -689,122 +687,6 @@ class TestTimecop < Minitest::Test
     assert Time.now != date
   ensure
     Timecop.thread_safe = false
-  end
-
-  if RUBY_VERSION >= '2.1.0'
-    def test_process_clock_gettime_monotonic
-      Timecop.freeze do
-        assert_same(*consecutive_monotonic, "CLOCK_MONOTONIC is not frozen")
-      end
-
-      initial_time = monotonic
-      Timecop.freeze(-0.5) do
-        assert_operator(monotonic, :<, initial_time, "CLOCK_MONOTONIC is not traveling back in time")
-      end
-    end
-
-    def test_process_clock_gettime_monotonic_nested
-      Timecop.freeze do
-        parent = monotonic
-
-        sleep(TIME_EPSILON)
-
-        delta = 0.5
-        Timecop.freeze(delta) do
-          child = monotonic
-          assert_equal(child, parent + delta, "Nested freeze not working for monotonic time")
-        end
-      end
-    end
-
-    def test_process_clock_gettime_monotonic_travel
-      initial_time = monotonic
-      Timecop.travel do
-        refute_same(*consecutive_monotonic, "CLOCK_MONOTONIC is frozen")
-        assert_operator(monotonic, :>, initial_time, "CLOCK_MONOTONIC is not moving forward")
-      end
-
-      Timecop.travel(-0.5) do
-        refute_same(*consecutive_monotonic, "CLOCK_MONOTONIC is frozen")
-        assert_operator(monotonic, :<, initial_time, "CLOCK_MONOTONIC is not traveling properly")
-      end
-    end
-
-    def test_process_clock_gettime_monotonic_scale
-      scale = 4
-      sleep_length = 0.25
-      Timecop.scale(scale) do
-        initial_time = monotonic
-        sleep(sleep_length)
-        expected_time = initial_time + (scale * sleep_length)
-        assert_times_effectively_equal expected_time, monotonic, 0.1, "CLOCK_MONOTONIC is not scaling"
-      end
-    end
-
-    def test_process_clock_gettime_realtime
-      Timecop.freeze do
-        assert_same(*consecutive_realtime, "CLOCK_REALTIME is not frozen")
-      end
-
-      initial_time = realtime
-      Timecop.freeze(-20) do
-        assert_operator(realtime, :<, initial_time, "CLOCK_REALTIME is not traveling back in time")
-      end
-    end
-
-    def test_process_clock_gettime_realtime_travel
-      initial_time = realtime
-      Timecop.travel do
-        refute_equal consecutive_realtime, "CLOCK_REALTIME is frozen"
-        assert_operator(realtime, :>, initial_time, "CLOCK_REALTIME is not moving forward")
-      end
-
-      delta = 0.1
-      Timecop.travel(Time.now - delta) do
-        refute_equal consecutive_realtime, "CLOCK_REALTIME is frozen"
-        assert_operator(realtime, :<, initial_time, "CLOCK_REALTIME is not traveling properly")
-        sleep(delta)
-        assert_operator(realtime, :>, initial_time, "CLOCK_REALTIME is not traveling properly")
-      end
-    end
-
-    def test_process_clock_gettime_realtime_scale
-      scale = 4
-      sleep_length = 0.25
-      Timecop.scale(scale) do
-        initial_time = realtime
-        sleep(sleep_length)
-        assert_operator(initial_time + scale * sleep_length, :<, realtime, "CLOCK_REALTIME is not scaling")
-      end
-    end
-  end
-
-  private
-
-  if RUBY_VERSION >= '2.1.0'
-    def monotonic
-      Process.clock_gettime(Process::CLOCK_MONOTONIC)
-    end
-
-    def realtime
-      Process.clock_gettime(Process::CLOCK_REALTIME)
-    end
-
-    def consecutive_monotonic
-      consecutive_times(:monotonic)
-    end
-
-    def consecutive_realtime
-      consecutive_times(:realtime)
-    end
-
-    def consecutive_times(time_method)
-      t1 = send(time_method)
-      sleep(TIME_EPSILON)
-      t2 = send(time_method)
-
-      [t1, t2]
-    end
   end
 
   def with_safe_mode(enabled=true)

--- a/test/timecop_test.rb
+++ b/test/timecop_test.rb
@@ -689,6 +689,8 @@ class TestTimecop < Minitest::Test
     Timecop.thread_safe = false
   end
 
+  private
+
   def with_safe_mode(enabled=true)
     mode = Timecop.safe_mode?
     Timecop.safe_mode = enabled

--- a/test/timecop_with_process_clock_test.rb
+++ b/test/timecop_with_process_clock_test.rb
@@ -20,6 +20,22 @@ class TestTimecopWithProcessClock < Minitest::Test
       end
     end
 
+    def test_process_clock_gettime_monotonic_with_date_freeze
+      date = Date.new(2024, 6, 1)
+      monotonic1 = Timecop.freeze(date) { monotonic }
+      monotonic2 = Timecop.freeze(date) { monotonic }
+
+      refute_equal(monotonic1, monotonic2, "CLOCK_MONOTONIC is not expected to freeze deterministically with a date")
+    end
+
+    def test_process_clock_gettime_realtime_with_date_freeze
+      date = Date.new(2024, 6, 1)
+      realtime_1 = Timecop.freeze(date) { realtime }
+      realtime_2 = Timecop.freeze(date) { realtime }
+
+      assert_equal(realtime_1, realtime_2, "CLOCK_REALTIME is expected to support freezing with a date")
+    end
+
     def test_process_clock_gettime_units_integer
       Timecop.freeze do
         time_in_nanoseconds = Process.clock_gettime(Process::CLOCK_MONOTONIC, :nanosecond)

--- a/test/timecop_with_process_clock_test.rb
+++ b/test/timecop_with_process_clock_test.rb
@@ -20,6 +20,34 @@ class TestTimecopWithProcessClock < Minitest::Test
       end
     end
 
+    def test_process_clock_gettime_units_integer
+      Timecop.freeze do
+        time_in_nanoseconds = Process.clock_gettime(Process::CLOCK_MONOTONIC, :nanosecond)
+        time_in_microseconds = Process.clock_gettime(Process::CLOCK_MONOTONIC, :microsecond)
+        time_in_milliseconds = Process.clock_gettime(Process::CLOCK_MONOTONIC, :millisecond)
+        time_in_seconds = Process.clock_gettime(Process::CLOCK_MONOTONIC, :second)
+
+        assert_equal(time_in_microseconds, (time_in_nanoseconds / 10**3).to_i)
+        assert_equal(time_in_milliseconds, (time_in_nanoseconds / 10**6).to_i)
+        assert_equal(time_in_seconds, (time_in_nanoseconds / 10**9).to_i)
+      end
+    end
+
+    def test_process_clock_gettime_units_float
+      Timecop.freeze do
+        time_in_nanoseconds = Process.clock_gettime(Process::CLOCK_MONOTONIC, :nanosecond).to_f
+
+        float_microseconds = Process.clock_gettime(Process::CLOCK_MONOTONIC, :float_microsecond)
+        float_milliseconds = Process.clock_gettime(Process::CLOCK_MONOTONIC, :float_millisecond)
+        float_seconds = Process.clock_gettime(Process::CLOCK_MONOTONIC, :float_second)
+
+        delta = 0.000001
+        assert_in_delta(float_microseconds, time_in_nanoseconds / 10**3, delta)
+        assert_in_delta(float_milliseconds, time_in_nanoseconds / 10**6, delta)
+        assert_in_delta(float_seconds, time_in_nanoseconds / 10**9, delta)
+      end
+    end
+
     def test_process_clock_gettime_monotonic_nested
       Timecop.freeze do
         parent = monotonic

--- a/test/timecop_with_process_clock_test.rb
+++ b/test/timecop_with_process_clock_test.rb
@@ -1,0 +1,124 @@
+require_relative "test_helper"
+require 'timecop'
+
+class TestTimecopWithProcessClock < Minitest::Test
+  TIME_EPSILON = 0.001 # seconds - represents enough time for Process.clock_gettime to have advanced if not frozen
+
+  def teardown
+    Timecop.return
+  end
+
+  if RUBY_VERSION >= '2.1.0'
+    def test_process_clock_gettime_monotonic
+      Timecop.freeze do
+        assert_same(*consecutive_monotonic, "CLOCK_MONOTONIC is not frozen")
+      end
+
+      initial_time = monotonic
+      Timecop.freeze(-0.5) do
+        assert_operator(monotonic, :<, initial_time, "CLOCK_MONOTONIC is not traveling back in time")
+      end
+    end
+
+    def test_process_clock_gettime_monotonic_nested
+      Timecop.freeze do
+        parent = monotonic
+
+        sleep(TIME_EPSILON)
+
+        delta = 0.5
+        Timecop.freeze(delta) do
+          child = monotonic
+          assert_equal(child, parent + delta, "Nested freeze not working for monotonic time")
+        end
+      end
+    end
+
+    def test_process_clock_gettime_monotonic_travel
+      initial_time = monotonic
+      Timecop.travel do
+        refute_same(*consecutive_monotonic, "CLOCK_MONOTONIC is frozen")
+        assert_operator(monotonic, :>, initial_time, "CLOCK_MONOTONIC is not moving forward")
+      end
+
+      Timecop.travel(-0.5) do
+        refute_same(*consecutive_monotonic, "CLOCK_MONOTONIC is frozen")
+        assert_operator(monotonic, :<, initial_time, "CLOCK_MONOTONIC is not traveling properly")
+      end
+    end
+
+    def test_process_clock_gettime_monotonic_scale
+      scale = 4
+      sleep_length = 0.25
+      Timecop.scale(scale) do
+        initial_time = monotonic
+        sleep(sleep_length)
+        expected_time = initial_time + (scale * sleep_length)
+        assert_times_effectively_equal expected_time, monotonic, 0.1, "CLOCK_MONOTONIC is not scaling"
+      end
+    end
+
+    def test_process_clock_gettime_realtime
+      Timecop.freeze do
+        assert_same(*consecutive_realtime, "CLOCK_REALTIME is not frozen")
+      end
+
+      initial_time = realtime
+      Timecop.freeze(-20) do
+        assert_operator(realtime, :<, initial_time, "CLOCK_REALTIME is not traveling back in time")
+      end
+    end
+
+    def test_process_clock_gettime_realtime_travel
+      initial_time = realtime
+      Timecop.travel do
+        refute_equal consecutive_realtime, "CLOCK_REALTIME is frozen"
+        assert_operator(realtime, :>, initial_time, "CLOCK_REALTIME is not moving forward")
+      end
+
+      delta = 0.1
+      Timecop.travel(Time.now - delta) do
+        refute_equal consecutive_realtime, "CLOCK_REALTIME is frozen"
+        assert_operator(realtime, :<, initial_time, "CLOCK_REALTIME is not traveling properly")
+        sleep(delta)
+        assert_operator(realtime, :>, initial_time, "CLOCK_REALTIME is not traveling properly")
+      end
+    end
+
+    def test_process_clock_gettime_realtime_scale
+      scale = 4
+      sleep_length = 0.25
+      Timecop.scale(scale) do
+        initial_time = realtime
+        sleep(sleep_length)
+        assert_operator(initial_time + scale * sleep_length, :<, realtime, "CLOCK_REALTIME is not scaling")
+      end
+    end
+
+    private
+
+    def monotonic
+      Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    end
+
+    def realtime
+      Process.clock_gettime(Process::CLOCK_REALTIME)
+    end
+
+    def consecutive_monotonic
+      consecutive_times(:monotonic)
+    end
+
+    def consecutive_realtime
+      consecutive_times(:realtime)
+    end
+
+    def consecutive_times(time_method)
+      t1 = send(time_method)
+      sleep(TIME_EPSILON)
+      t2 = send(time_method)
+
+      [t1, t2]
+    end
+  end
+end


### PR DESCRIPTION
I am interested in being able to use Timecop with `Process.clock_gettime`. I saw https://github.com/travisjeffery/timecop/issues/220 (the request for this) and https://github.com/travisjeffery/timecop/pull/258 (the PR that implemented it).

This code is nearly the same as https://github.com/travisjeffery/timecop/pull/258; I have only made minor changes.