### PR TITLE
Revert "Calculate travel_offset to align with the precision of argument to Timecop.travel"

### DIFF
--- a/History.md
+++ b/History.md
@@ -2,8 +2,6 @@
 
 ## Unreleased
 
-- Calculate travel_offset to align with the precision of argument to Timecop.travel ([#421](https://github.com/travisjeffery/timecop/pull/421))
-
 ## v0.9.10
 
 - Make Process.clock_gettime configurable and turned off by default (for backwards compatability) ([#427](https://github.com/travisjeffery/timecop/pull/427))

--- a/lib/timecop/time_stack_item.rb
+++ b/lib/timecop/time_stack_item.rb
@@ -157,7 +157,7 @@ class Timecop
     end
 
     def compute_travel_offset
-      time.to_r - Time.now_without_mock_time.to_r
+      time - Time.now_without_mock_time
     end
 
     def times_are_equal_within_epsilon t1, t2, epsilon_in_seconds

--- a/test/time_stack_item_test.rb
+++ b/test/time_stack_item_test.rb
@@ -296,22 +296,4 @@ class TestTimeStackItem < Minitest::Test
       assert_equal dt, now, "#{dt.to_f}, #{now.to_f}"
     end
   end
-
-  def test_travel_offset_aligns_to_clock
-    t = Time.now
-    stack_item = Timecop::TimeStackItem.new(:travel, t)
-    travel_offset_denom = stack_item.travel_offset.to_r.denominator
-    clock_resolution = Process.clock_getres(:CLOCK_REALTIME, :hertz)
-    assert_equal 0, clock_resolution.modulo(travel_offset_denom),
-      "travel offset precision (#{travel_offset_denom}) does not align with clock resolution (#{clock_resolution})"
-  end
-
-  def test_travel_offset_aligns_to_travel_time
-    t = Time.now + 0.001_002_003_004
-    stack_item = Timecop::TimeStackItem.new(:travel, t)
-    travel_offset_denom = stack_item.travel_offset.to_r.denominator
-    travel_time_denom = t.to_r.denominator
-    assert_equal 0, travel_time_denom.modulo(travel_offset_denom),
-      "travel offset precision (#{travel_offset_denom}) does not align with travel time precision (#{travel_time_denom})"
-  end
 end


### PR DESCRIPTION
I ran tests locally for this PR and THOUGHT they passed but I must have screwed up. Reverting for now.

Reverts travisjeffery/timecop#421