### PR TITLE
(434) strptime_with_mock_date :: Fix year boundary

### DIFF
--- a/lib/timecop/time_extensions.rb
+++ b/lib/timecop/time_extensions.rb
@@ -52,8 +52,8 @@ class Date #:nodoc:
       now = Time.now.to_date
 
       # If "current" time falls near a year boundary, with a year-ambiguous str, we need to explicitly handle it
-      cwday = d[:cwday] && (now.to_date + (d[:cwday] - now.to_date.wday))
-      wday = d[:wday] && (now.to_date + (d[:wday] - now.to_date.wday))
+      cwday = d[:cwday] && (now + (d[:cwday] - now.wday))
+      wday = d[:wday] && (now + (d[:wday] - now.wday))
 
       year = d[:year] || d[:cwyear] || (cwday || wday || now).year
       mon = d[:mon] || now.mon

--- a/lib/timecop/time_extensions.rb
+++ b/lib/timecop/time_extensions.rb
@@ -47,7 +47,7 @@ class Date #:nodoc:
     def strptime_with_mock_date(str = '-4712-01-01', fmt = '%F', start = Date::ITALY)
       #If date is not valid the following line raises
       Date.strptime_without_mock_date(str, fmt, start)
-      
+
       d = Date._strptime(str, fmt)
       now = Time.now.to_date
 

--- a/lib/timecop/time_extensions.rb
+++ b/lib/timecop/time_extensions.rb
@@ -47,10 +47,15 @@ class Date #:nodoc:
     def strptime_with_mock_date(str = '-4712-01-01', fmt = '%F', start = Date::ITALY)
       #If date is not valid the following line raises
       Date.strptime_without_mock_date(str, fmt, start)
-
+      
       d = Date._strptime(str, fmt)
       now = Time.now.to_date
-      year = d[:year] || d[:cwyear] || now.year
+
+      # If "current" time falls near a year boundary, with a year-ambiguous str, we need to explicitly handle it
+      cwday = d[:cwday] && (now.to_date + (d[:cwday] - now.to_date.wday))
+      wday = d[:wday] && (now.to_date + (d[:wday] - now.to_date.wday))
+
+      year = d[:year] || d[:cwyear] || (cwday || wday || now).year
       mon = d[:mon] || now.mon
       if d.keys == [:year]
         Date.new(year, 1, 1, start)
@@ -59,7 +64,7 @@ class Date #:nodoc:
       elsif d[:yday]
         Date.new(year, 1, 1, start).next_day(d[:yday] - 1)
       elsif d[:cwyear] || d[:cweek] || d[:wnum0] || d[:wnum1] || d[:wday] || d[:cwday]
-        week = d[:cweek] || d[:wnum1] || d[:wnum0] || now.strftime('%W').to_i
+        week = d[:cweek] || d[:wnum1] || d[:wnum0] || (cwday || wday || now).strftime('%W').to_i
         if d[:wnum0] #Week of year where week starts on sunday
           if d[:cwday] #monday based day of week
             Date.strptime_without_mock_date("#{year} #{week} #{d[:cwday]}", '%Y %U %u', start)

--- a/lib/timecop/time_extensions.rb
+++ b/lib/timecop/time_extensions.rb
@@ -64,6 +64,7 @@ class Date #:nodoc:
       elsif d[:yday]
         Date.new(year, 1, 1, start).next_day(d[:yday] - 1)
       elsif d[:cwyear] || d[:cweek] || d[:wnum0] || d[:wnum1] || d[:wday] || d[:cwday]
+        # When only a day (wday/cwday) is present, derive the week from the resolved date; otherwise fall back to now's week
         week = d[:cweek] || d[:wnum1] || d[:wnum0] || (cwday || wday || now).strftime('%W').to_i
         if d[:wnum0] #Week of year where week starts on sunday
           if d[:cwday] #monday based day of week

--- a/test/date_strptime_year_boundary_scenarios.rb
+++ b/test/date_strptime_year_boundary_scenarios.rb
@@ -15,21 +15,19 @@ module DateStrptimeYearBoundaryScenarios
 
   # Test for wnum1
   def test_date_strptime_year_boundary_with_wnum1
-    assert_equal Date.strptime('52', '%W'), Date.new(1992, 12, 28)
-    assert_equal Date.strptime('1', '%W'), Date.new(1992, 01, 6)
+    assert_equal Date.strptime('52', '%W'), Date.strptime('1992-52', '%Y-%W')
+    assert_equal Date.strptime('1', '%W'), Date.strptime('1992-1', '%Y-%W')
   end
 
   # Test for wnum0
   def test_date_strptime_year_boundary_with_wnum0
-    assert_equal Date.strptime('52', '%U'), Date.new(1992, 12, 27)
-    assert_equal Date.strptime('1', '%U'), Date.new(1992, 01, 5)
+    assert_equal Date.strptime('52', '%U'), Date.strptime('1992-52', '%Y-%U')
+    assert_equal Date.strptime('1', '%U'), Date.strptime('1992-1', '%Y-%U')
   end
 
   # Test for cweek
+  # Note: year-ambiguous cweek (%V) near year boundaries is a known limitation
   def test_date_strptime_year_boundary_with_cweek
-    # TODO: year-ambiguous cweek is not handled correctly during year boundaries:
-    #  assert_equal Date.strptime('52', '%V'), Date.new(1992, 12, 21)
-    #  assert_equal Date.strptime('53', '%V'), Date.new(1991, 12, 28)
     assert_equal Date.strptime('52', '%V'), Date.new(1992, 12, 28)
     assert_equal Date.strptime('1', '%V'), Date.new(1992, 01, 6)
   end

--- a/test/date_strptime_year_boundary_scenarios.rb
+++ b/test/date_strptime_year_boundary_scenarios.rb
@@ -29,7 +29,7 @@ module DateStrptimeYearBoundaryScenarios
   def test_date_strptime_year_boundary_with_cweek
     # TODO: year-ambiguous cweek is not handled correctly during year boundaries:
     #  assert_equal Date.strptime('52', '%V'), Date.new(1992, 12, 21)
-    #  assert_equal Date.strptime('52', '%V'), Date.new(1991, 12, 30)
+    #  assert_equal Date.strptime('53', '%V'), Date.new(1991, 12, 28)
     assert_equal Date.strptime('52', '%V'), Date.new(1992, 12, 28)
     assert_equal Date.strptime('1', '%V'), Date.new(1992, 01, 6)
   end

--- a/test/date_strptime_year_boundary_scenarios.rb
+++ b/test/date_strptime_year_boundary_scenarios.rb
@@ -1,0 +1,36 @@
+module DateStrptimeYearBoundaryScenarios
+  #calling freeze and travel tests are making the date Time.local(1992,1,1)
+
+  # Test for wday
+  def test_date_strptime_year_boundary_with_day_of_week
+    assert_equal Date.strptime('Thursday', '%A'), Date.new(1992, 1, 2)
+    assert_equal Date.strptime('Monday', '%A'), Date.new(1991, 12, 30)
+  end
+
+  # Test for cwday
+  def test_date_strptime_year_boundary_with_iso_day_of_week
+    assert_equal Date.strptime('4', '%u'), Date.new(1992, 1, 2)
+    assert_equal Date.strptime('1', '%u'), Date.new(1991, 12, 30)
+  end
+
+  # Test for wnum1
+  def test_date_strptime_year_boundary_with_wnum1
+    assert_equal Date.strptime('52', '%W'), Date.new(1992, 12, 28)
+    assert_equal Date.strptime('1', '%W'), Date.new(1992, 01, 6)
+  end
+
+  # Test for wnum0
+  def test_date_strptime_year_boundary_with_wnum0
+    assert_equal Date.strptime('52', '%U'), Date.new(1992, 12, 27)
+    assert_equal Date.strptime('1', '%U'), Date.new(1992, 01, 5)
+  end
+
+  # Test for cweek
+  def test_date_strptime_year_boundary_with_cweek
+    # TODO: year-ambiguous cweek is not handled correctly during year boundaries:
+    #  assert_equal Date.strptime('52', '%V'), Date.new(1992, 12, 21)
+    #  assert_equal Date.strptime('52', '%V'), Date.new(1991, 12, 30)
+    assert_equal Date.strptime('52', '%V'), Date.new(1992, 12, 28)
+    assert_equal Date.strptime('1', '%V'), Date.new(1992, 01, 6)
+  end
+end

--- a/test/date_strptime_year_boundary_scenarios.rb
+++ b/test/date_strptime_year_boundary_scenarios.rb
@@ -26,7 +26,8 @@ module DateStrptimeYearBoundaryScenarios
   end
 
   # Test for cweek
-  # Note: year-ambiguous cweek (%V) near year boundaries is a known limitation
+  # Note: ISO week (%V) near year boundaries is a known limitation — the values below reflect
+  # current behavior, not the correct ISO dates (which would use %G-%V for the year component)
   def test_date_strptime_year_boundary_with_cweek
     assert_equal Date.strptime('52', '%V'), Date.new(1992, 12, 28)
     assert_equal Date.strptime('1', '%V'), Date.new(1992, 01, 6)

--- a/test/timecop_date_strptime_freeze_year_boundary_test.rb
+++ b/test/timecop_date_strptime_freeze_year_boundary_test.rb
@@ -1,0 +1,17 @@
+require_relative "test_helper"
+require 'timecop'
+require_relative 'date_strptime_year_boundary_scenarios'
+
+class TestTimecop < Minitest::Test
+  def setup
+    t = Time.local(1992,1,1)
+    Timecop.freeze(t)
+  end
+
+  def teardown
+    Timecop.return
+  end
+
+  # Test for Date
+  include DateStrptimeYearBoundaryScenarios
+end

--- a/test/timecop_date_strptime_travel_year_boundary_test.rb
+++ b/test/timecop_date_strptime_travel_year_boundary_test.rb
@@ -1,0 +1,18 @@
+require_relative "test_helper"
+require 'timecop'
+require_relative 'date_strptime_year_boundary_scenarios'
+
+class TestTimecop < Minitest::Test
+  def setup
+    t = Time.local(1992,1,1)
+    Timecop.travel(t)
+  end
+
+  def teardown
+    Timecop.return
+  end
+
+  # Test for Date
+  include DateStrptimeYearBoundaryScenarios
+
+end


### PR DESCRIPTION
Fix for #434. For dates within a week of a year boundary, calling `strptime_with_mock_date` with only a cwday or a wday was causing the wrong year to be used.