### PR TITLE
Calculate `travel_offset` to align with the precision of argument to `Timecop.travel`, again

### DIFF
--- a/History.md
+++ b/History.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Calculate travel_offset to align with the precision of argument to Timecop.travel ([#447](https://github.com/travisjeffery/timecop/pull/447))
+
 ## v0.9.11
 
 - Fix Time.new keyword arguments on JRuby 10 ([#443](https://github.com/travisjeffery/timecop/pull/443))

--- a/lib/timecop/time_stack_item.rb
+++ b/lib/timecop/time_stack_item.rb
@@ -155,7 +155,7 @@ class Timecop
     end
 
     def compute_travel_offset
-      time - Time.now_without_mock_time
+      time.to_r - Time.now_without_mock_time.to_r
     end
 
     def times_are_equal_within_epsilon t1, t2, epsilon_in_seconds

--- a/test/time_stack_item_test.rb
+++ b/test/time_stack_item_test.rb
@@ -296,4 +296,22 @@ class TestTimeStackItem < Minitest::Test
       assert_equal dt, now, "#{dt.to_f}, #{now.to_f}"
     end
   end
+
+  def test_travel_offset_aligns_to_clock
+    clock_resolution = Process.clock_getres(:CLOCK_REALTIME, :hertz).to_i
+    Time.stubs(:now_without_mock_time).returns(Time.at(1_500_000_000))
+    t = Time.at(Rational(4_000_000_000 * clock_resolution + clock_resolution - 1, clock_resolution))
+    stack_item = Timecop::TimeStackItem.new(:travel, t)
+    travel_offset_denom = stack_item.travel_offset.to_r.denominator
+    assert_equal 0, clock_resolution.modulo(travel_offset_denom),
+      "travel offset precision (#{travel_offset_denom}) does not align with clock resolution (#{clock_resolution})"
+  end
+
+  def test_travel_offset_aligns_to_travel_time
+    Time.stubs(:now_without_mock_time).returns(Time.at(Rational(1_500_000_000_123_456_789, 1_000_000_000)))
+    t = Time.at(4_000_000_000) + 0.001_002_003_004
+    stack_item = Timecop::TimeStackItem.new(:travel, t)
+    assert_equal t, stack_item.time
+    assert_equal t.nsec, stack_item.time.nsec
+  end
 end


### PR DESCRIPTION
Note: This change is identical to #421 with different tests, as the previous attempt was flakey.

Subtracting two Times returns a Float, which may not be accurate down to subsecond resolution. Because Floats are stored as double-precision values (IEEE 754), they can have resolutions much higher than the typical minimum clock precision of 10e-9 seconds. Which can result in two Time object not comparing as equal when they are the same down to the nanosecond, when one has had a `travel_offset` applied to it.

The previous tests would sometimes fail because both built their travel time from `Time.now`, while `TimeStackItem` sampled the clock a second time internally, so the offset under test varied between runs.

The travel time assertion required the offset's denominator to divide the travel time's. But the travel time comes from one `Time.now` sample and the offset from a second one taken a moment later, and subtracting them needs a common denominator, which is always a multiple of the travel time's. The assertion can only hold when that multiple is the travel time's denominator, when the second sample's denominator happens to divide the first's. It does so about five times in six, independent of the host clock's resolution, which is how the change came to be merged and then reverted.

The tests now stub `Time.now_without_mock_time`, build travel times from constants far enough out that a Float offset loses nanoseconds, and assert exact equality against `stack_item.time` and its `nsec`.

Fixes #420